### PR TITLE
Prototype compliance service for reasoner API message object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,138 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# IDE
+.idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: python
+python:
+  - "3.7"
+
+install:
+  - "pip install -r requirements.txt"
+
+before_script:
+  - "export PYTHONPATH=.:$PYTHONPATH"
+
+script:
+  - "pytest tests/"

--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
 ## BioLink Compliance Service
+
+[![Build Status](https://travis-ci.org/TranslatorIIPrototypes/BLComplianceService.svg?branch=master)](https://travis-ci.org/TranslatorIIPrototypes/BLComplianceService)
+
+Validates a ReasonerAPI message for BioLink compliance
+
+
+### Geting started
+
+This service requires python 3.7+
+
+    pip install -r requirements.txt
+    uvicorn bl_compliance.server:app --reload --port 8000
+    
+### Background
+
+In the first phase of Translator, the knowledge graph standards working group
+created a standard schema for data transfer between reasoners, and a standard
+for representing graphs called the BioLink model. The knowledge graph portion of the
+reasoner schema defines the graph required to answer a query. For practical reasons,
+this schema is a more liberal superset of the BioLink Model schema.
+
+This service validates the knowledge graph portion of a ReasonerAPI message. Users
+can submit either a message object, or the knowledge graph portion of the Reasoner API standard.
+
+Reasoner API examples:  
+Robokop: https://robokop.renci.org/apidocs/  
+ICEES: https://icees.renci.org/apidocs/  
+RTX: https://arax.rtx.ai/api/rtx/v1/ui/  
+
+### Related Repos
+
+BioLink Model: https://github.com/biolink/biolink-model  
+Translator Reasoners API: https://github.com/NCATS-Tangerine/NCATS-ReasonerStdAPI  
+Reasoner API validation service: http://transltr.io:7071/apidocs  

--- a/bl_compliance/models/edge.py
+++ b/bl_compliance/models/edge.py
@@ -1,0 +1,29 @@
+from typing import Union, List, Mapping, Any, Optional
+from pydantic.dataclasses import dataclass
+
+
+class Config:
+    orm_mode = True
+
+
+@dataclass(init=False, config=Config)
+class Edge:
+    id: str
+    source_id: str
+    target_id: str
+    type: Optional[Union[str, List]] = None
+    kwargs: Optional[Mapping[Any, Any]] = None
+
+    def __init__(
+            self,
+            id: str,
+            source_id: str,
+            target_id: str,
+            type: Optional[Union[str, List]] = None,
+            **kwargs
+    ):
+        self.id = id
+        self.source_id = source_id
+        self.target_id = target_id
+        self.type = type
+        self.kwargs = kwargs

--- a/bl_compliance/models/errors.py
+++ b/bl_compliance/models/errors.py
@@ -1,0 +1,7 @@
+from dataclasses import dataclass
+
+
+@dataclass()
+class TransformationError:
+    error_type: str
+    message: str

--- a/bl_compliance/models/knowledge_graph.py
+++ b/bl_compliance/models/knowledge_graph.py
@@ -1,0 +1,25 @@
+from typing import List, Mapping, Any, Optional, Union
+from pydantic.dataclasses import dataclass
+from .node import Node
+from .edge import Edge
+
+
+class Config:
+    orm_mode = True
+
+
+@dataclass(init=False, config=Config)
+class KnowledgeGraph:
+    nodes: List[Node]
+    edges: List[Edge]
+    kwargs: Optional[Mapping[Any, Any]] = None
+
+    def __init__(
+            self,
+            nodes: List[Node],
+            edges: List[Edge],
+            **kwargs
+    ):
+        self.nodes = nodes
+        self.edges = edges
+        self.kwargs = kwargs

--- a/bl_compliance/models/message.py
+++ b/bl_compliance/models/message.py
@@ -1,0 +1,27 @@
+from pydantic.dataclasses import dataclass
+from typing import List, Mapping, Any, Optional, Dict
+from .knowledge_graph import KnowledgeGraph
+
+
+class Config:
+    orm_mode = True
+
+
+@dataclass(init=False, config=Config)
+class Message():
+    knowledge_graph: KnowledgeGraph
+    results: Optional[List[Any]] = None
+    query_graph: Optional[Dict] = None
+    kwargs: Optional[Mapping[Any, Any]] = None
+
+    def __init__(
+            self,
+            knowledge_graph: KnowledgeGraph,
+            results: Optional[List[Any]] = None,
+            query_graph: Optional[Dict] = None,
+            **kwargs
+    ):
+        self.knowledge_graph = knowledge_graph
+        self.results = results
+        self.query_graph = query_graph
+        self.kwargs = kwargs

--- a/bl_compliance/models/node.py
+++ b/bl_compliance/models/node.py
@@ -1,0 +1,26 @@
+from typing import Union, List, Mapping, Any, Optional
+from pydantic.dataclasses import dataclass
+
+
+class Config:
+    orm_mode = True
+
+
+@dataclass(init=False, config=Config)
+class Node:
+    id: str
+    name: Optional[str] = None
+    type: Optional[Union[str, List]] = None
+    kwargs: Optional[Mapping[Any, Any]] = None
+
+    def __init__(
+            self,
+            id: str,
+            name: Optional[str] = None,
+            type: Optional[Union[str, List]] = None,
+            **kwargs
+    ):
+        self.id = id
+        self.name = name
+        self.type = type
+        self.kwargs = kwargs

--- a/bl_compliance/server.py
+++ b/bl_compliance/server.py
@@ -1,0 +1,67 @@
+"""FastAPI BL compliance server."""
+import yaml
+import requests
+import json
+from pathlib import Path
+from typing import Union, Dict, Any, List
+from fastapi import FastAPI, Body
+from starlette.responses import JSONResponse
+from starlette.requests import Request
+from .validator import validate_with_jsonschema, validate_with_kgx
+from .models.knowledge_graph import KnowledgeGraph
+from .models.message import Message
+
+
+# Custom exception handler
+class BlValidationException(Exception):
+    def __init__(self, content: List):
+        self.content = content
+
+
+app = FastAPI(
+    title="BioLink Compliance Service",
+    version="0.0.1",
+    description="Utilities for checking compliance with the BioLink Model",
+)
+
+config_path = Path(__file__).parent.parent / 'conf' / 'config.yaml'
+config_fh = open(config_path, 'r')
+config = yaml.load(config_fh, Loader=yaml.SafeLoader)
+
+example_fh = Path(__file__).parent.parent / 'resources' / 'validate_kg_example.json'
+
+with open(example_fh) as json_data:
+    val_kg_example = json.load(json_data)
+
+req = requests.get(config['biolink_model'])
+biolink_schema = req.json()
+
+
+@app.exception_handler(BlValidationException)
+async def blvalidation_exception_handler(request: Request, exc: BlValidationException):
+    return JSONResponse(
+        status_code=418,
+        content=[content.__dict__ for content in exc.content],
+    )
+
+@app.post('/validate/knowledge_graph', response_model=Dict[Any, Any])
+async def validate_knowledge_graph(
+        data: Union[KnowledgeGraph, Message] = Body(..., example=val_kg_example)
+):
+    """
+    Validates a knowledge graph against the BioLink model
+    """
+    #json_validation = validate_with_jsonschema(biolink_schema, data)
+    kgx_validation = validate_with_kgx(data)
+    if kgx_validation:
+        raise BlValidationException(content=kgx_validation)
+    return {"message": "Successfully validated"}
+
+
+@app.get("/version")
+async def get_version():
+    """
+    Get the versions of the Biolink Model JSON schema
+    and the Reasoner API standard
+    """
+    return config

--- a/bl_compliance/validator.py
+++ b/bl_compliance/validator.py
@@ -1,0 +1,66 @@
+"""
+Functions for validating knowledge graphs against biolink model
+using KGX and json schema
+"""
+from typing import List, Union, Dict
+from kgx.transformers.rsa_transformer import RsaTransformer
+from kgx.validator import Validator, NodeError, EdgeError
+from dataclasses import asdict
+import fastjsonschema
+from jsonschema import validate as jsonvalidate
+from .models.knowledge_graph import KnowledgeGraph
+from .models.message import Message
+from .models.errors import TransformationError
+
+
+
+def validate_with_kgx(
+        data: Union[Dict, KnowledgeGraph, Message]
+) -> List[Union[NodeError, EdgeError, TransformationError]]:
+    """
+    Validate a rsa knowledge graph with kgx
+
+    First transforms the graph using the RsaTransformer, then
+    performs validation with the Validator class
+    :param data:
+    :return:
+    """
+    if isinstance(data, Message):
+        message = asdict(data)
+    elif isinstance(data, KnowledgeGraph):
+        message = {
+            'knowledge_graph': asdict(data)
+        }
+    elif 'knowledge_graph' not in data:
+        message = {
+            'knowledge_graph': data
+        }
+    else:
+        message = data
+
+    biolinkified = RsaTransformer()
+
+    try:
+        biolinkified.load(message)
+    except KeyError as exc:
+        return [
+            TransformationError(
+                error_type="TransformationError",
+                message="Could not transform reasoner "
+                        "message into biolink graph: {}".format(str(exc)),
+        )]
+    validator = Validator()
+    validator.validate(biolinkified.graph)
+
+    return validator.errors
+
+
+def validate_with_jsonschema(schema: Dict, data: Union[KnowledgeGraph, Message]):
+    #jsonvalidate(instance=data, schema=schema)
+    return
+
+
+def validate_with_fastjsonschema(schema: Dict, data: Union[KnowledgeGraph, Message]):
+    #validate = fastjsonschema.compile(schema, data)
+    #validate(data)
+    return

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -1,0 +1,7 @@
+# TODO anchor these in versions
+
+# Used for validation
+biolink_model: "https://raw.githubusercontent.com/biolink/biolink-model/master/json-schema/biolink-model.json"
+
+# Used to generate python dataclasses
+reasoner_api_model: "https://raw.githubusercontent.com/NCATS-Tangerine/NCATS-ReasonerStdAPI/master/API/TranslatorReasonersAPI.yaml"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+fastapi
+uvicorn
+pyyaml
+git+git://github.com/NCATS-Tangerine/kgx@master
+fastjsonschema
+requests

--- a/resources/validate_kg_example.json
+++ b/resources/validate_kg_example.json
@@ -1,0 +1,20 @@
+{
+  "edges": [
+    {
+      "id": "553903",
+      "source_id": "https://omim.org/entry/603903",
+      "target_id": "https://www.uniprot.org/uniprot/P00738",
+      "relation_label": ["affects"],
+      "additionalProp1": {}
+    }
+  ],
+  "nodes": [
+    {
+      "id": "OMIM:603903",
+      "name": "Haptoglobin",
+      "type": "Disease",
+      "additionalProp1": {}
+    }
+  ],
+  "additionalProp1": {}
+}

--- a/tests/resources/biolink-compliant.json
+++ b/tests/resources/biolink-compliant.json
@@ -1,0 +1,22 @@
+{
+  "edges": [
+    {
+      "id": "553903",
+      "source_id": "https://omim.org/entry/603903",
+      "target_id": "http://www.uniprot.org/uniprot/P00738",
+      "edge_label": "affects"
+    }
+  ],
+  "nodes": [
+    {
+      "id": "OMIM:603903",
+      "name": "Haptoglobin",
+      "category": "Disease"
+    },
+    {
+      "id": "UniProt:P00738",
+      "name": "HP",
+      "category": "Gene"
+    }
+  ]
+}

--- a/tests/resources/inval-reasoner-std.json
+++ b/tests/resources/inval-reasoner-std.json
@@ -1,0 +1,10 @@
+{
+  "nodes": [
+    {
+      "id": "OMIM:603903",
+      "name": "Haptoglobin",
+      "additionalProp1": {}
+    }
+  ],
+  "additionalProp1": {}
+}

--- a/tests/resources/inval-reasoner-std2.json
+++ b/tests/resources/inval-reasoner-std2.json
@@ -1,0 +1,19 @@
+{
+  "edges": [
+    {
+      "id": {"553903": 1},
+      "source_id": "https://omim.org/entry/603903",
+      "target_id": "https://www.uniprot.org/uniprot/P00738",
+      "type": "affects",
+      "additionalProp1": {}
+    }
+  ],
+  "nodes": [
+    {
+      "id": "OMIM:603903",
+      "name": "Haptoglobin",
+      "additionalProp1": {}
+    }
+  ],
+  "additionalProp1": {}
+}

--- a/tests/resources/ncats.json
+++ b/tests/resources/ncats.json
@@ -1,0 +1,19 @@
+{
+  "edges": [
+    {
+      "id": "553903",
+      "source_id": "https://omim.org/entry/603903",
+      "target_id": "https://www.uniprot.org/uniprot/P00738",
+      "type": "affects",
+      "additionalProp1": {}
+    }
+  ],
+  "nodes": [
+    {
+      "id": "OMIM:603903",
+      "name": "Haptoglobin",
+      "additionalProp1": {}
+    }
+  ],
+  "additionalProp1": {}
+}

--- a/tests/resources/robokop.json
+++ b/tests/resources/robokop.json
@@ -1,0 +1,9600 @@
+{
+  "knowledge_graph": {
+    "edges": [
+      {
+        "ctime": [
+          1573150906.2001512,
+          1572931709.117001
+        ],
+        "edge_source": [
+          "pharos.disease_get_gene",
+          "pharos.gene_get_disease"
+        ],
+        "id": "cf93c3bac618b3a1196da225e9078a38",
+        "predicate_id": "NCIT:R176",
+        "publications": [],
+        "relation": [
+          "PHAROS:gene_involved",
+          "PHAROS:gene_involved"
+        ],
+        "relation_label": [
+          "gene_involved",
+          "gene_involved"
+        ],
+        "source_database": [
+          "pharos",
+          "pharos"
+        ],
+        "source_id": "MONDO:0019501",
+        "target_id": "HGNC:16361",
+        "type": "disease_to_gene_association"
+      },
+      {
+        "ctime": [
+          1573150911.5783074,
+          1572931707.7467363
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene",
+          "biolink.gene_get_disease"
+        ],
+        "id": "a77742d4b029b9dbf3bd55957fa57767",
+        "predicate_id": "RO:0002326",
+        "publications": [],
+        "relation": [
+          "RO:0003304",
+          "RO:0003304"
+        ],
+        "relation_label": [
+          "contributes to condition",
+          "contributes to condition"
+        ],
+        "source_database": [
+          "biolink",
+          "biolink"
+        ],
+        "source_id": "HGNC:16361",
+        "target_id": "MONDO:0019501",
+        "type": "contributes_to"
+      },
+      {
+        "ctime": [
+          1573150911.5824635
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "6d6c2034a641b7a634a36318ca2d6ceb",
+        "predicate_id": "RO:0002410",
+        "publications": [
+          "PMID:17171570"
+        ],
+        "relation": [
+          "RO:0003303"
+        ],
+        "relation_label": [
+          "causes condition"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:16361",
+        "target_id": "MONDO:0019501",
+        "type": "causes"
+      },
+      {
+        "ctime": [
+          1573151074.5653973
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "633dfcffcd41fe1543f42980aa76aca6",
+        "predicate_id": "RO:0002326",
+        "publications": [],
+        "relation": [
+          "RO:0003304"
+        ],
+        "relation_label": [
+          "contributes to condition"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:16361",
+        "target_id": "MONDO:0019589",
+        "type": "contributes_to"
+      },
+      {
+        "ctime": [
+          1573151074.5822334
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "311d5920e28d96b99c3dfda0689b9828",
+        "predicate_id": "RO:0002410",
+        "publications": [
+          "PMID:17171570"
+        ],
+        "relation": [
+          "RO:0003303"
+        ],
+        "relation_label": [
+          "causes condition"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:16361",
+        "target_id": "MONDO:0019589",
+        "type": "causes"
+      },
+      {
+        "ctime": [
+          1573151225.710789,
+          1572931873.8106158
+        ],
+        "edge_source": [
+          "pharos.disease_get_gene",
+          "pharos.gene_get_disease"
+        ],
+        "id": "21abfcf64d93b48ff888717b09e2ea81",
+        "predicate_id": "NCIT:R176",
+        "publications": [],
+        "relation": [
+          "PHAROS:gene_involved",
+          "PHAROS:gene_involved"
+        ],
+        "relation_label": [
+          "gene_involved",
+          "gene_involved"
+        ],
+        "source_database": [
+          "pharos",
+          "pharos"
+        ],
+        "source_id": "MONDO:0008947",
+        "target_id": "HGNC:17770",
+        "type": "disease_to_gene_association"
+      },
+      {
+        "ctime": [
+          1573151302.4305284
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "9846510f8558d5904c58b42ab952c922",
+        "predicate_id": "RO:0002326",
+        "publications": [],
+        "relation": [
+          "RO:0004013"
+        ],
+        "relation_label": [
+          "is causal germline mutation in"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:7897",
+        "target_id": "MONDO:0016397",
+        "type": "contributes_to"
+      },
+      {
+        "ctime": [
+          1573151302.4309134
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "d38d4a36db0b03e15c28426dc43752a3",
+        "predicate_id": "RO:0002410",
+        "publications": [
+          "PMID:16098014",
+          "PMID:22065762",
+          "PMID:19718781",
+          "PMID:26206375",
+          "PMID:27366019",
+          "PMID:15465421",
+          "PMID:27549128",
+          "PMID:25425405",
+          "PMID:27139891",
+          "PMID:20826119",
+          "PMID:29197565",
+          "PMID:11479732",
+          "PMID:21245028",
+          "PMID:11545687",
+          "PMID:24506780",
+          "PMID:4795418",
+          "PMID:20718790",
+          "PMID:11754101",
+          "PMID:26338816",
+          "PMID:20521171",
+          "PMID:29100954",
+          "PMID:17989072",
+          "PMID:18216017",
+          "PMID:22750297",
+          "PMID:25326637",
+          "PMID:10480349",
+          "PMID:9211849",
+          "PMID:23433426",
+          "PMID:26939636",
+          "PMID:27193329",
+          "PMID:9211850",
+          "PMID:25149939",
+          "PMID:16126423",
+          "PMID:12205649",
+          "PMID:9634529",
+          "PMID:25637190",
+          "PMID:11349231",
+          "PMID:23593294",
+          "PMID:23146215",
+          "PMID:16138904",
+          "PMID:22476655",
+          "PMID:12719428",
+          "PMID:26666848",
+          "PMID:23427322",
+          "PMID:16720792",
+          "PMID:10521297",
+          "PMID:19900398",
+          "PMID:23453666",
+          "PMID:28167839",
+          "PMID:24001525",
+          "PMID:19252935",
+          "PMID:24767253",
+          "PMID:12554680",
+          "PMID:10521290",
+          "PMID:17160617",
+          "PMID:27238017",
+          "PMID:19013089",
+          "PMID:26108224",
+          "PMID:11333381",
+          "PMID:27900365",
+          "PMID:25131710",
+          "PMID:28222799",
+          "PMID:24676439",
+          "PMID:23653225",
+          "PMID:28193631",
+          "PMID:23430855",
+          "PMID:11182931",
+          "PMID:12401890",
+          "PMID:26981555",
+          "PMID:15459971",
+          "PMID:19206179",
+          "PMID:15130691",
+          "PMID:27959697",
+          "PMID:15596783",
+          "PMID:23773996",
+          "PMID:19744920",
+          "PMID:19223215",
+          "PMID:23142039",
+          "PMID:24915861",
+          "PMID:22326530",
+          "PMID:25349751",
+          "PMID:22704015",
+          "PMID:24570279",
+          "PMID:9927649",
+          "PMID:25764212",
+          "PMID:24386122",
+          "PMID:27581084",
+          "PMID:26937389",
+          "PMID:17003072",
+          "PMID:25236789",
+          "PMID:12955717",
+          "PMID:27378690",
+          "PMID:26984608",
+          "PMID:27706244",
+          "PMID:19609713",
+          "PMID:3378364",
+          "PMID:28802248",
+          "PMID:26019327",
+          "PMID:15774455",
+          "PMID:12408188",
+          "PMID:23774949",
+          "PMID:22505584",
+          "PMID:28130309",
+          "PMID:12974729",
+          "PMID:22676771",
+          "PMID:28480683",
+          "PMID:28155026",
+          "PMID:19307542",
+          "PMID:16778374"
+        ],
+        "relation": [
+          "RO:0003303"
+        ],
+        "relation_label": [
+          "causes condition"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:7897",
+        "target_id": "MONDO:0016397",
+        "type": "causes"
+      },
+      {
+        "ctime": [
+          1573151511.4045908,
+          1572931709.119164
+        ],
+        "edge_source": [
+          "pharos.disease_get_gene",
+          "pharos.gene_get_disease"
+        ],
+        "id": "b289c17ac16111cc0586d64e1ae61440",
+        "predicate_id": "NCIT:R176",
+        "publications": [],
+        "relation": [
+          "PHAROS:gene_involved",
+          "PHAROS:gene_involved"
+        ],
+        "relation_label": [
+          "gene_involved",
+          "gene_involved"
+        ],
+        "source_database": [
+          "pharos",
+          "pharos"
+        ],
+        "source_id": "MONDO:0016484",
+        "target_id": "HGNC:16361",
+        "type": "disease_to_gene_association"
+      },
+      {
+        "ctime": [
+          1573151514.7406008,
+          1572931707.74699
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene",
+          "biolink.gene_get_disease"
+        ],
+        "id": "5e03ac014213498f5b88d2b14d29d2bd",
+        "predicate_id": "RO:0002326",
+        "publications": [],
+        "relation": [
+          "RO:0004013",
+          "RO:0004013"
+        ],
+        "relation_label": [
+          "is causal germline mutation in",
+          "is causal germline mutation in"
+        ],
+        "source_database": [
+          "biolink",
+          "biolink"
+        ],
+        "source_id": "HGNC:16361",
+        "target_id": "MONDO:0016484",
+        "type": "contributes_to"
+      },
+      {
+        "ctime": [
+          1573151514.7405605
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "1ce6376d302bf13aa0d2645319103552",
+        "predicate_id": "RO:0002410",
+        "publications": [
+          "PMID:17171570"
+        ],
+        "relation": [
+          "RO:0003303"
+        ],
+        "relation_label": [
+          "causes condition"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:16361",
+        "target_id": "MONDO:0016484",
+        "type": "causes"
+      },
+      {
+        "ctime": [
+          1573152037.2550907
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "b31f28f221f3f7c8ea44d5318441aeb6",
+        "predicate_id": "RO:0002326",
+        "publications": [],
+        "relation": [
+          "RO:0003304"
+        ],
+        "relation_label": [
+          "contributes to condition"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:16361",
+        "target_id": "MONDO:0000429",
+        "type": "contributes_to"
+      },
+      {
+        "ctime": [
+          1573152037.2571387
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "b919f4e2cf5332b3d09111b2c9011fc2",
+        "predicate_id": "RO:0002326",
+        "publications": [],
+        "relation": [
+          "RO:0004013"
+        ],
+        "relation_label": [
+          "is causal germline mutation in"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:30922",
+        "target_id": "MONDO:0000429",
+        "type": "contributes_to"
+      },
+      {
+        "ctime": [
+          1573152037.257182
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "d9090cae0c3101d1a7e3523ecc42796b",
+        "predicate_id": "RO:0002410",
+        "publications": [
+          "PMID:21937992",
+          "PMID:23773660"
+        ],
+        "relation": [
+          "RO:0003303"
+        ],
+        "relation_label": [
+          "causes condition"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:30922",
+        "target_id": "MONDO:0000429",
+        "type": "causes"
+      },
+      {
+        "ctime": [
+          1573152037.3698647
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "5f1a25c39c27e23a12e003d91856e343",
+        "predicate_id": "RO:0002410",
+        "publications": [
+          "PMID:16098014",
+          "PMID:22065762",
+          "PMID:19718781",
+          "PMID:26206375",
+          "PMID:27366019",
+          "PMID:15465421",
+          "PMID:27549128",
+          "PMID:25425405",
+          "PMID:27139891",
+          "PMID:20826119",
+          "PMID:29197565",
+          "PMID:11479732",
+          "PMID:21245028",
+          "PMID:11545687",
+          "PMID:24506780",
+          "PMID:4795418",
+          "PMID:20718790",
+          "PMID:11754101",
+          "PMID:26338816",
+          "PMID:20521171",
+          "PMID:29100954",
+          "PMID:17989072",
+          "PMID:18216017",
+          "PMID:22750297",
+          "PMID:25326637",
+          "PMID:10480349",
+          "PMID:9211849",
+          "PMID:23433426",
+          "PMID:26939636",
+          "PMID:27193329",
+          "PMID:9211850",
+          "PMID:25149939",
+          "PMID:16126423",
+          "PMID:12205649",
+          "PMID:9634529",
+          "PMID:25637190",
+          "PMID:11349231",
+          "PMID:23593294",
+          "PMID:23146215",
+          "PMID:16138904",
+          "PMID:22476655",
+          "PMID:12719428",
+          "PMID:26666848",
+          "PMID:23427322",
+          "PMID:16720792",
+          "PMID:10521297",
+          "PMID:19900398",
+          "PMID:23453666",
+          "PMID:28167839",
+          "PMID:24001525",
+          "PMID:19252935",
+          "PMID:24767253",
+          "PMID:12554680",
+          "PMID:10521290",
+          "PMID:17160617",
+          "PMID:27238017",
+          "PMID:19013089",
+          "PMID:26108224",
+          "PMID:11333381",
+          "PMID:27900365",
+          "PMID:25131710",
+          "PMID:28222799",
+          "PMID:24676439",
+          "PMID:23653225",
+          "PMID:28193631",
+          "PMID:23430855",
+          "PMID:11182931",
+          "PMID:12401890",
+          "PMID:26981555",
+          "PMID:15459971",
+          "PMID:19206179",
+          "PMID:15130691",
+          "PMID:27959697",
+          "PMID:15596783",
+          "PMID:23773996",
+          "PMID:19744920",
+          "PMID:19223215",
+          "PMID:23142039",
+          "PMID:24915861",
+          "PMID:22326530",
+          "PMID:25349751",
+          "PMID:22704015",
+          "PMID:24570279",
+          "PMID:9927649",
+          "PMID:25764212",
+          "PMID:24386122",
+          "PMID:27581084",
+          "PMID:26937389",
+          "PMID:17003072",
+          "PMID:25236789",
+          "PMID:12955717",
+          "PMID:27378690",
+          "PMID:26984608",
+          "PMID:27706244",
+          "PMID:19609713",
+          "PMID:3378364",
+          "PMID:28802248",
+          "PMID:26019327",
+          "PMID:15774455",
+          "PMID:12408188",
+          "PMID:23774949",
+          "PMID:22505584",
+          "PMID:28130309",
+          "PMID:12974729",
+          "PMID:22676771",
+          "PMID:28480683",
+          "PMID:28155026",
+          "PMID:19307542",
+          "PMID:16778374"
+        ],
+        "relation": [
+          "RO:0003303"
+        ],
+        "relation_label": [
+          "causes condition"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:7897",
+        "target_id": "MONDO:0000429",
+        "type": "causes"
+      },
+      {
+        "ctime": [
+          1573152037.3694832
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "d2093587dc8d1907b3d511120be8c278",
+        "predicate_id": "RO:0002326",
+        "publications": [],
+        "relation": [
+          "RO:0004013"
+        ],
+        "relation_label": [
+          "is causal germline mutation in"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:7897",
+        "target_id": "MONDO:0000429",
+        "type": "contributes_to"
+      },
+      {
+        "ctime": [
+          1573152037.378259
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "f88d5132c2d327e1db9bf1e0d99d5097",
+        "predicate_id": "RO:0002410",
+        "publications": [
+          "PMID:15841483",
+          "PMID:12833159",
+          "PMID:11973626"
+        ],
+        "relation": [
+          "RO:0003303"
+        ],
+        "relation_label": [
+          "causes condition"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:16361",
+        "target_id": "MONDO:0000429",
+        "type": "causes"
+      },
+      {
+        "ctime": [
+          1573152607.173713
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "435a6e9d85c117b00867c124c4a37f1d",
+        "predicate_id": "RO:0002326",
+        "publications": [],
+        "relation": [
+          "RO:0004013"
+        ],
+        "relation_label": [
+          "is causal germline mutation in"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:7897",
+        "target_id": "MONDO:0017133",
+        "type": "contributes_to"
+      },
+      {
+        "ctime": [
+          1573152607.174129
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "875ac63cded21b98f6d17ec6434b5bac",
+        "predicate_id": "RO:0002410",
+        "publications": [
+          "PMID:16098014",
+          "PMID:22065762",
+          "PMID:19718781",
+          "PMID:26206375",
+          "PMID:27366019",
+          "PMID:15465421",
+          "PMID:27549128",
+          "PMID:25425405",
+          "PMID:27139891",
+          "PMID:20826119",
+          "PMID:29197565",
+          "PMID:11479732",
+          "PMID:21245028",
+          "PMID:11545687",
+          "PMID:24506780",
+          "PMID:4795418",
+          "PMID:20718790",
+          "PMID:11754101",
+          "PMID:26338816",
+          "PMID:20521171",
+          "PMID:29100954",
+          "PMID:17989072",
+          "PMID:18216017",
+          "PMID:22750297",
+          "PMID:25326637",
+          "PMID:10480349",
+          "PMID:9211849",
+          "PMID:23433426",
+          "PMID:26939636",
+          "PMID:27193329",
+          "PMID:9211850",
+          "PMID:25149939",
+          "PMID:16126423",
+          "PMID:12205649",
+          "PMID:9634529",
+          "PMID:25637190",
+          "PMID:11349231",
+          "PMID:23593294",
+          "PMID:23146215",
+          "PMID:16138904",
+          "PMID:22476655",
+          "PMID:12719428",
+          "PMID:26666848",
+          "PMID:23427322",
+          "PMID:16720792",
+          "PMID:10521297",
+          "PMID:19900398",
+          "PMID:23453666",
+          "PMID:28167839",
+          "PMID:24001525",
+          "PMID:19252935",
+          "PMID:24767253",
+          "PMID:12554680",
+          "PMID:10521290",
+          "PMID:17160617",
+          "PMID:27238017",
+          "PMID:19013089",
+          "PMID:26108224",
+          "PMID:11333381",
+          "PMID:27900365",
+          "PMID:25131710",
+          "PMID:28222799",
+          "PMID:24676439",
+          "PMID:23653225",
+          "PMID:28193631",
+          "PMID:23430855",
+          "PMID:11182931",
+          "PMID:12401890",
+          "PMID:26981555",
+          "PMID:15459971",
+          "PMID:19206179",
+          "PMID:15130691",
+          "PMID:27959697",
+          "PMID:15596783",
+          "PMID:23773996",
+          "PMID:19744920",
+          "PMID:19223215",
+          "PMID:23142039",
+          "PMID:24915861",
+          "PMID:22326530",
+          "PMID:25349751",
+          "PMID:22704015",
+          "PMID:24570279",
+          "PMID:9927649",
+          "PMID:25764212",
+          "PMID:24386122",
+          "PMID:27581084",
+          "PMID:26937389",
+          "PMID:17003072",
+          "PMID:25236789",
+          "PMID:12955717",
+          "PMID:27378690",
+          "PMID:26984608",
+          "PMID:27706244",
+          "PMID:19609713",
+          "PMID:3378364",
+          "PMID:28802248",
+          "PMID:26019327",
+          "PMID:15774455",
+          "PMID:12408188",
+          "PMID:23774949",
+          "PMID:22505584",
+          "PMID:28130309",
+          "PMID:12974729",
+          "PMID:22676771",
+          "PMID:28480683",
+          "PMID:28155026",
+          "PMID:19307542",
+          "PMID:16778374"
+        ],
+        "relation": [
+          "RO:0003303"
+        ],
+        "relation_label": [
+          "causes condition"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:7897",
+        "target_id": "MONDO:0017133",
+        "type": "causes"
+      },
+      {
+        "ctime": [
+          1573152597.2369335
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "9803d1f391fe69f2d28c1609d8b3a497",
+        "predicate_id": "RO:0002326",
+        "publications": [],
+        "relation": [
+          "RO:0004013"
+        ],
+        "relation_label": [
+          "is causal germline mutation in"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:7897",
+        "target_id": "MONDO:0020142",
+        "type": "contributes_to"
+      },
+      {
+        "ctime": [
+          1573152605.0650017
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "8cc5bc109a2887b23d10ac245c426758",
+        "predicate_id": "RO:0002326",
+        "publications": [],
+        "relation": [
+          "RO:0004013"
+        ],
+        "relation_label": [
+          "is causal germline mutation in"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:7897",
+        "target_id": "MONDO:0020143",
+        "type": "contributes_to"
+      },
+      {
+        "ctime": [
+          1573152597.237331
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "23aece11aac64f64fbdc5225f85ae3af",
+        "predicate_id": "RO:0002410",
+        "publications": [
+          "PMID:16098014",
+          "PMID:22065762",
+          "PMID:19718781",
+          "PMID:26206375",
+          "PMID:27366019",
+          "PMID:15465421",
+          "PMID:27549128",
+          "PMID:25425405",
+          "PMID:27139891",
+          "PMID:20826119",
+          "PMID:29197565",
+          "PMID:11479732",
+          "PMID:21245028",
+          "PMID:11545687",
+          "PMID:24506780",
+          "PMID:4795418",
+          "PMID:20718790",
+          "PMID:11754101",
+          "PMID:26338816",
+          "PMID:20521171",
+          "PMID:29100954",
+          "PMID:17989072",
+          "PMID:18216017",
+          "PMID:22750297",
+          "PMID:25326637",
+          "PMID:10480349",
+          "PMID:9211849",
+          "PMID:23433426",
+          "PMID:26939636",
+          "PMID:27193329",
+          "PMID:9211850",
+          "PMID:25149939",
+          "PMID:16126423",
+          "PMID:12205649",
+          "PMID:9634529",
+          "PMID:25637190",
+          "PMID:11349231",
+          "PMID:23593294",
+          "PMID:23146215",
+          "PMID:16138904",
+          "PMID:22476655",
+          "PMID:12719428",
+          "PMID:26666848",
+          "PMID:23427322",
+          "PMID:16720792",
+          "PMID:10521297",
+          "PMID:19900398",
+          "PMID:23453666",
+          "PMID:28167839",
+          "PMID:24001525",
+          "PMID:19252935",
+          "PMID:24767253",
+          "PMID:12554680",
+          "PMID:10521290",
+          "PMID:17160617",
+          "PMID:27238017",
+          "PMID:19013089",
+          "PMID:26108224",
+          "PMID:11333381",
+          "PMID:27900365",
+          "PMID:25131710",
+          "PMID:28222799",
+          "PMID:24676439",
+          "PMID:23653225",
+          "PMID:28193631",
+          "PMID:23430855",
+          "PMID:11182931",
+          "PMID:12401890",
+          "PMID:26981555",
+          "PMID:15459971",
+          "PMID:19206179",
+          "PMID:15130691",
+          "PMID:27959697",
+          "PMID:15596783",
+          "PMID:23773996",
+          "PMID:19744920",
+          "PMID:19223215",
+          "PMID:23142039",
+          "PMID:24915861",
+          "PMID:22326530",
+          "PMID:25349751",
+          "PMID:22704015",
+          "PMID:24570279",
+          "PMID:9927649",
+          "PMID:25764212",
+          "PMID:24386122",
+          "PMID:27581084",
+          "PMID:26937389",
+          "PMID:17003072",
+          "PMID:25236789",
+          "PMID:12955717",
+          "PMID:27378690",
+          "PMID:26984608",
+          "PMID:27706244",
+          "PMID:19609713",
+          "PMID:3378364",
+          "PMID:28802248",
+          "PMID:26019327",
+          "PMID:15774455",
+          "PMID:12408188",
+          "PMID:23774949",
+          "PMID:22505584",
+          "PMID:28130309",
+          "PMID:12974729",
+          "PMID:22676771",
+          "PMID:28480683",
+          "PMID:28155026",
+          "PMID:19307542",
+          "PMID:16778374"
+        ],
+        "relation": [
+          "RO:0003303"
+        ],
+        "relation_label": [
+          "causes condition"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:7897",
+        "target_id": "MONDO:0020142",
+        "type": "causes"
+      },
+      {
+        "ctime": [
+          1573152605.065826
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "8da518c0ebf67fecacff4fe6b4341f11",
+        "predicate_id": "RO:0002410",
+        "publications": [
+          "PMID:16098014",
+          "PMID:22065762",
+          "PMID:19718781",
+          "PMID:26206375",
+          "PMID:27366019",
+          "PMID:15465421",
+          "PMID:27549128",
+          "PMID:25425405",
+          "PMID:27139891",
+          "PMID:20826119",
+          "PMID:29197565",
+          "PMID:11479732",
+          "PMID:21245028",
+          "PMID:11545687",
+          "PMID:24506780",
+          "PMID:4795418",
+          "PMID:20718790",
+          "PMID:11754101",
+          "PMID:26338816",
+          "PMID:20521171",
+          "PMID:29100954",
+          "PMID:17989072",
+          "PMID:18216017",
+          "PMID:22750297",
+          "PMID:25326637",
+          "PMID:10480349",
+          "PMID:9211849",
+          "PMID:23433426",
+          "PMID:26939636",
+          "PMID:27193329",
+          "PMID:9211850",
+          "PMID:25149939",
+          "PMID:16126423",
+          "PMID:12205649",
+          "PMID:9634529",
+          "PMID:25637190",
+          "PMID:11349231",
+          "PMID:23593294",
+          "PMID:23146215",
+          "PMID:16138904",
+          "PMID:22476655",
+          "PMID:12719428",
+          "PMID:26666848",
+          "PMID:23427322",
+          "PMID:16720792",
+          "PMID:10521297",
+          "PMID:19900398",
+          "PMID:23453666",
+          "PMID:28167839",
+          "PMID:24001525",
+          "PMID:19252935",
+          "PMID:24767253",
+          "PMID:12554680",
+          "PMID:10521290",
+          "PMID:17160617",
+          "PMID:27238017",
+          "PMID:19013089",
+          "PMID:26108224",
+          "PMID:11333381",
+          "PMID:27900365",
+          "PMID:25131710",
+          "PMID:28222799",
+          "PMID:24676439",
+          "PMID:23653225",
+          "PMID:28193631",
+          "PMID:23430855",
+          "PMID:11182931",
+          "PMID:12401890",
+          "PMID:26981555",
+          "PMID:15459971",
+          "PMID:19206179",
+          "PMID:15130691",
+          "PMID:27959697",
+          "PMID:15596783",
+          "PMID:23773996",
+          "PMID:19744920",
+          "PMID:19223215",
+          "PMID:23142039",
+          "PMID:24915861",
+          "PMID:22326530",
+          "PMID:25349751",
+          "PMID:22704015",
+          "PMID:24570279",
+          "PMID:9927649",
+          "PMID:25764212",
+          "PMID:24386122",
+          "PMID:27581084",
+          "PMID:26937389",
+          "PMID:17003072",
+          "PMID:25236789",
+          "PMID:12955717",
+          "PMID:27378690",
+          "PMID:26984608",
+          "PMID:27706244",
+          "PMID:19609713",
+          "PMID:3378364",
+          "PMID:28802248",
+          "PMID:26019327",
+          "PMID:15774455",
+          "PMID:12408188",
+          "PMID:23774949",
+          "PMID:22505584",
+          "PMID:28130309",
+          "PMID:12974729",
+          "PMID:22676771",
+          "PMID:28480683",
+          "PMID:28155026",
+          "PMID:19307542",
+          "PMID:16778374"
+        ],
+        "relation": [
+          "RO:0003303"
+        ],
+        "relation_label": [
+          "causes condition"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:7897",
+        "target_id": "MONDO:0020143",
+        "type": "causes"
+      },
+      {
+        "ctime": [
+          1573152904.9700925,
+          1572931709.1177087
+        ],
+        "edge_source": [
+          "pharos.disease_get_gene",
+          "pharos.gene_get_disease"
+        ],
+        "id": "d1724be72c0e2d857100bd1c872f5fa7",
+        "predicate_id": "NCIT:R176",
+        "publications": [],
+        "relation": [
+          "PHAROS:gene_involved",
+          "PHAROS:gene_involved"
+        ],
+        "relation_label": [
+          "gene_involved",
+          "gene_involved"
+        ],
+        "source_database": [
+          "pharos",
+          "pharos"
+        ],
+        "source_id": "MONDO:0017312",
+        "target_id": "HGNC:16361",
+        "type": "disease_to_gene_association"
+      },
+      {
+        "ctime": [
+          1573152937.9203243
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "c2a611028dc277518276c075e19fd637",
+        "predicate_id": "RO:0002326",
+        "publications": [],
+        "relation": [
+          "RO:0003304"
+        ],
+        "relation_label": [
+          "contributes to condition"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:16361",
+        "target_id": "MONDO:0020238",
+        "type": "contributes_to"
+      },
+      {
+        "ctime": [
+          1573152937.9623067
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "c76a335306c1a59c00829625f3fa79e2",
+        "predicate_id": "RO:0002326",
+        "publications": [],
+        "relation": [
+          "RO:0004013"
+        ],
+        "relation_label": [
+          "is causal germline mutation in"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:7897",
+        "target_id": "MONDO:0020238",
+        "type": "contributes_to"
+      },
+      {
+        "ctime": [
+          1573152937.9626722
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "adee1288f560956e607a04f76bc90838",
+        "predicate_id": "RO:0002410",
+        "publications": [
+          "PMID:16098014",
+          "PMID:22065762",
+          "PMID:19718781",
+          "PMID:26206375",
+          "PMID:27366019",
+          "PMID:15465421",
+          "PMID:27549128",
+          "PMID:25425405",
+          "PMID:27139891",
+          "PMID:20826119",
+          "PMID:29197565",
+          "PMID:11479732",
+          "PMID:21245028",
+          "PMID:11545687",
+          "PMID:24506780",
+          "PMID:4795418",
+          "PMID:20718790",
+          "PMID:11754101",
+          "PMID:26338816",
+          "PMID:20521171",
+          "PMID:29100954",
+          "PMID:17989072",
+          "PMID:18216017",
+          "PMID:22750297",
+          "PMID:25326637",
+          "PMID:10480349",
+          "PMID:9211849",
+          "PMID:23433426",
+          "PMID:26939636",
+          "PMID:27193329",
+          "PMID:9211850",
+          "PMID:25149939",
+          "PMID:16126423",
+          "PMID:12205649",
+          "PMID:9634529",
+          "PMID:25637190",
+          "PMID:11349231",
+          "PMID:23593294",
+          "PMID:23146215",
+          "PMID:16138904",
+          "PMID:22476655",
+          "PMID:12719428",
+          "PMID:26666848",
+          "PMID:23427322",
+          "PMID:16720792",
+          "PMID:10521297",
+          "PMID:19900398",
+          "PMID:23453666",
+          "PMID:28167839",
+          "PMID:24001525",
+          "PMID:19252935",
+          "PMID:24767253",
+          "PMID:12554680",
+          "PMID:10521290",
+          "PMID:17160617",
+          "PMID:27238017",
+          "PMID:19013089",
+          "PMID:26108224",
+          "PMID:11333381",
+          "PMID:27900365",
+          "PMID:25131710",
+          "PMID:28222799",
+          "PMID:24676439",
+          "PMID:23653225",
+          "PMID:28193631",
+          "PMID:23430855",
+          "PMID:11182931",
+          "PMID:12401890",
+          "PMID:26981555",
+          "PMID:15459971",
+          "PMID:19206179",
+          "PMID:15130691",
+          "PMID:27959697",
+          "PMID:15596783",
+          "PMID:23773996",
+          "PMID:19744920",
+          "PMID:19223215",
+          "PMID:23142039",
+          "PMID:24915861",
+          "PMID:22326530",
+          "PMID:25349751",
+          "PMID:22704015",
+          "PMID:24570279",
+          "PMID:9927649",
+          "PMID:25764212",
+          "PMID:24386122",
+          "PMID:27581084",
+          "PMID:26937389",
+          "PMID:17003072",
+          "PMID:25236789",
+          "PMID:12955717",
+          "PMID:27378690",
+          "PMID:26984608",
+          "PMID:27706244",
+          "PMID:19609713",
+          "PMID:3378364",
+          "PMID:28802248",
+          "PMID:26019327",
+          "PMID:15774455",
+          "PMID:12408188",
+          "PMID:23774949",
+          "PMID:22505584",
+          "PMID:28130309",
+          "PMID:12974729",
+          "PMID:22676771",
+          "PMID:28480683",
+          "PMID:28155026",
+          "PMID:19307542",
+          "PMID:16778374"
+        ],
+        "relation": [
+          "RO:0003303"
+        ],
+        "relation_label": [
+          "causes condition"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:7897",
+        "target_id": "MONDO:0020238",
+        "type": "causes"
+      },
+      {
+        "ctime": [
+          1573152937.9667654
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "b57584541e714064e5f6ac8ca2bbb798",
+        "predicate_id": "RO:0002410",
+        "publications": [
+          "PMID:17171570"
+        ],
+        "relation": [
+          "RO:0003303"
+        ],
+        "relation_label": [
+          "causes condition"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:16361",
+        "target_id": "MONDO:0020238",
+        "type": "causes"
+      },
+      {
+        "ctime": [
+          1573152953.4663846
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "03532f464a7d1574133c6b9a4603d218",
+        "predicate_id": "RO:0002326",
+        "publications": [],
+        "relation": [
+          "RO:0003304"
+        ],
+        "relation_label": [
+          "contributes to condition"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:16361",
+        "target_id": "MONDO:0020240",
+        "type": "contributes_to"
+      },
+      {
+        "ctime": [
+          1573152972.5718746
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "017e9913dedbc4d3af38ab478db90900",
+        "predicate_id": "RO:0002326",
+        "publications": [],
+        "relation": [
+          "RO:0004013"
+        ],
+        "relation_label": [
+          "is causal germline mutation in"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:7897",
+        "target_id": "MONDO:0020242",
+        "type": "contributes_to"
+      },
+      {
+        "ctime": [
+          1573152995.1252415
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "4a300978c71130b47e86455619ae437c",
+        "predicate_id": "RO:0002326",
+        "publications": [],
+        "relation": [
+          "RO:0004013"
+        ],
+        "relation_label": [
+          "is causal germline mutation in"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:7897",
+        "target_id": "MONDO:0020244",
+        "type": "contributes_to"
+      },
+      {
+        "ctime": [
+          1573152953.4777718
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "8594f5f3ace2358b02a50567aff09fff",
+        "predicate_id": "RO:0002410",
+        "publications": [
+          "PMID:17171570"
+        ],
+        "relation": [
+          "RO:0003303"
+        ],
+        "relation_label": [
+          "causes condition"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:16361",
+        "target_id": "MONDO:0020240",
+        "type": "causes"
+      },
+      {
+        "ctime": [
+          1573152972.5727606
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "5b4a451e1268a95b4730c621e832aa8b",
+        "predicate_id": "RO:0002410",
+        "publications": [
+          "PMID:16098014",
+          "PMID:22065762",
+          "PMID:19718781",
+          "PMID:26206375",
+          "PMID:27366019",
+          "PMID:15465421",
+          "PMID:27549128",
+          "PMID:25425405",
+          "PMID:27139891",
+          "PMID:20826119",
+          "PMID:29197565",
+          "PMID:11479732",
+          "PMID:21245028",
+          "PMID:11545687",
+          "PMID:24506780",
+          "PMID:4795418",
+          "PMID:20718790",
+          "PMID:11754101",
+          "PMID:26338816",
+          "PMID:20521171",
+          "PMID:29100954",
+          "PMID:17989072",
+          "PMID:18216017",
+          "PMID:22750297",
+          "PMID:25326637",
+          "PMID:10480349",
+          "PMID:9211849",
+          "PMID:23433426",
+          "PMID:26939636",
+          "PMID:27193329",
+          "PMID:9211850",
+          "PMID:25149939",
+          "PMID:16126423",
+          "PMID:12205649",
+          "PMID:9634529",
+          "PMID:25637190",
+          "PMID:11349231",
+          "PMID:23593294",
+          "PMID:23146215",
+          "PMID:16138904",
+          "PMID:22476655",
+          "PMID:12719428",
+          "PMID:26666848",
+          "PMID:23427322",
+          "PMID:16720792",
+          "PMID:10521297",
+          "PMID:19900398",
+          "PMID:23453666",
+          "PMID:28167839",
+          "PMID:24001525",
+          "PMID:19252935",
+          "PMID:24767253",
+          "PMID:12554680",
+          "PMID:10521290",
+          "PMID:17160617",
+          "PMID:27238017",
+          "PMID:19013089",
+          "PMID:26108224",
+          "PMID:11333381",
+          "PMID:27900365",
+          "PMID:25131710",
+          "PMID:28222799",
+          "PMID:24676439",
+          "PMID:23653225",
+          "PMID:28193631",
+          "PMID:23430855",
+          "PMID:11182931",
+          "PMID:12401890",
+          "PMID:26981555",
+          "PMID:15459971",
+          "PMID:19206179",
+          "PMID:15130691",
+          "PMID:27959697",
+          "PMID:15596783",
+          "PMID:23773996",
+          "PMID:19744920",
+          "PMID:19223215",
+          "PMID:23142039",
+          "PMID:24915861",
+          "PMID:22326530",
+          "PMID:25349751",
+          "PMID:22704015",
+          "PMID:24570279",
+          "PMID:9927649",
+          "PMID:25764212",
+          "PMID:24386122",
+          "PMID:27581084",
+          "PMID:26937389",
+          "PMID:17003072",
+          "PMID:25236789",
+          "PMID:12955717",
+          "PMID:27378690",
+          "PMID:26984608",
+          "PMID:27706244",
+          "PMID:19609713",
+          "PMID:3378364",
+          "PMID:28802248",
+          "PMID:26019327",
+          "PMID:15774455",
+          "PMID:12408188",
+          "PMID:23774949",
+          "PMID:22505584",
+          "PMID:28130309",
+          "PMID:12974729",
+          "PMID:22676771",
+          "PMID:28480683",
+          "PMID:28155026",
+          "PMID:19307542",
+          "PMID:16778374"
+        ],
+        "relation": [
+          "RO:0003303"
+        ],
+        "relation_label": [
+          "causes condition"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:7897",
+        "target_id": "MONDO:0020242",
+        "type": "causes"
+      },
+      {
+        "ctime": [
+          1573152995.1259975
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "3a4faa96fda18467f20c57e2698a5969",
+        "predicate_id": "RO:0002410",
+        "publications": [
+          "PMID:16098014",
+          "PMID:22065762",
+          "PMID:19718781",
+          "PMID:26206375",
+          "PMID:27366019",
+          "PMID:15465421",
+          "PMID:27549128",
+          "PMID:25425405",
+          "PMID:27139891",
+          "PMID:20826119",
+          "PMID:29197565",
+          "PMID:11479732",
+          "PMID:21245028",
+          "PMID:11545687",
+          "PMID:24506780",
+          "PMID:4795418",
+          "PMID:20718790",
+          "PMID:11754101",
+          "PMID:26338816",
+          "PMID:20521171",
+          "PMID:29100954",
+          "PMID:17989072",
+          "PMID:18216017",
+          "PMID:22750297",
+          "PMID:25326637",
+          "PMID:10480349",
+          "PMID:9211849",
+          "PMID:23433426",
+          "PMID:26939636",
+          "PMID:27193329",
+          "PMID:9211850",
+          "PMID:25149939",
+          "PMID:16126423",
+          "PMID:12205649",
+          "PMID:9634529",
+          "PMID:25637190",
+          "PMID:11349231",
+          "PMID:23593294",
+          "PMID:23146215",
+          "PMID:16138904",
+          "PMID:22476655",
+          "PMID:12719428",
+          "PMID:26666848",
+          "PMID:23427322",
+          "PMID:16720792",
+          "PMID:10521297",
+          "PMID:19900398",
+          "PMID:23453666",
+          "PMID:28167839",
+          "PMID:24001525",
+          "PMID:19252935",
+          "PMID:24767253",
+          "PMID:12554680",
+          "PMID:10521290",
+          "PMID:17160617",
+          "PMID:27238017",
+          "PMID:19013089",
+          "PMID:26108224",
+          "PMID:11333381",
+          "PMID:27900365",
+          "PMID:25131710",
+          "PMID:28222799",
+          "PMID:24676439",
+          "PMID:23653225",
+          "PMID:28193631",
+          "PMID:23430855",
+          "PMID:11182931",
+          "PMID:12401890",
+          "PMID:26981555",
+          "PMID:15459971",
+          "PMID:19206179",
+          "PMID:15130691",
+          "PMID:27959697",
+          "PMID:15596783",
+          "PMID:23773996",
+          "PMID:19744920",
+          "PMID:19223215",
+          "PMID:23142039",
+          "PMID:24915861",
+          "PMID:22326530",
+          "PMID:25349751",
+          "PMID:22704015",
+          "PMID:24570279",
+          "PMID:9927649",
+          "PMID:25764212",
+          "PMID:24386122",
+          "PMID:27581084",
+          "PMID:26937389",
+          "PMID:17003072",
+          "PMID:25236789",
+          "PMID:12955717",
+          "PMID:27378690",
+          "PMID:26984608",
+          "PMID:27706244",
+          "PMID:19609713",
+          "PMID:3378364",
+          "PMID:28802248",
+          "PMID:26019327",
+          "PMID:15774455",
+          "PMID:12408188",
+          "PMID:23774949",
+          "PMID:22505584",
+          "PMID:28130309",
+          "PMID:12974729",
+          "PMID:22676771",
+          "PMID:28480683",
+          "PMID:28155026",
+          "PMID:19307542",
+          "PMID:16778374"
+        ],
+        "relation": [
+          "RO:0003303"
+        ],
+        "relation_label": [
+          "causes condition"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:7897",
+        "target_id": "MONDO:0020244",
+        "type": "causes"
+      },
+      {
+        "ctime": [
+          1573153083.1388185,
+          1572909410.3887258
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene",
+          "biolink.gene_get_disease"
+        ],
+        "id": "f5d8c05c82dddfc2b5394339c9ce10fd",
+        "predicate_id": "RO:0002410",
+        "publications": [
+          "PMID:16098014",
+          "PMID:22065762",
+          "PMID:19718781",
+          "PMID:26206375",
+          "PMID:27366019",
+          "PMID:15465421",
+          "PMID:27549128",
+          "PMID:25425405",
+          "PMID:27139891",
+          "PMID:20826119",
+          "PMID:29197565",
+          "PMID:11479732",
+          "PMID:21245028",
+          "PMID:11545687",
+          "PMID:24506780",
+          "PMID:4795418",
+          "PMID:20718790",
+          "PMID:11754101",
+          "PMID:26338816",
+          "PMID:20521171",
+          "PMID:29100954",
+          "PMID:17989072",
+          "PMID:18216017",
+          "PMID:22750297",
+          "PMID:25326637",
+          "PMID:10480349",
+          "PMID:9211849",
+          "PMID:23433426",
+          "PMID:26939636",
+          "PMID:27193329",
+          "PMID:9211850",
+          "PMID:25149939",
+          "PMID:16126423",
+          "PMID:12205649",
+          "PMID:9634529",
+          "PMID:25637190",
+          "PMID:11349231",
+          "PMID:23593294",
+          "PMID:23146215",
+          "PMID:16138904",
+          "PMID:22476655",
+          "PMID:12719428",
+          "PMID:26666848",
+          "PMID:23427322",
+          "PMID:16720792",
+          "PMID:10521297",
+          "PMID:19900398",
+          "PMID:23453666",
+          "PMID:28167839",
+          "PMID:24001525",
+          "PMID:19252935",
+          "PMID:24767253",
+          "PMID:12554680",
+          "PMID:10521290",
+          "PMID:17160617",
+          "PMID:27238017",
+          "PMID:19013089",
+          "PMID:26108224",
+          "PMID:11333381",
+          "PMID:27900365",
+          "PMID:25131710",
+          "PMID:28222799",
+          "PMID:24676439",
+          "PMID:23653225",
+          "PMID:28193631",
+          "PMID:23430855",
+          "PMID:11182931",
+          "PMID:12401890",
+          "PMID:26981555",
+          "PMID:15459971",
+          "PMID:19206179",
+          "PMID:15130691",
+          "PMID:27959697",
+          "PMID:15596783",
+          "PMID:23773996",
+          "PMID:19744920",
+          "PMID:19223215",
+          "PMID:23142039",
+          "PMID:24915861",
+          "PMID:22326530",
+          "PMID:25349751",
+          "PMID:22704015",
+          "PMID:24570279",
+          "PMID:9927649",
+          "PMID:25764212",
+          "PMID:24386122",
+          "PMID:27581084",
+          "PMID:26937389",
+          "PMID:17003072",
+          "PMID:25236789",
+          "PMID:12955717",
+          "PMID:27378690",
+          "PMID:26984608",
+          "PMID:27706244",
+          "PMID:19609713",
+          "PMID:3378364",
+          "PMID:28802248",
+          "PMID:26019327",
+          "PMID:15774455",
+          "PMID:12408188",
+          "PMID:23774949",
+          "PMID:22505584",
+          "PMID:28130309",
+          "PMID:12974729",
+          "PMID:22676771",
+          "PMID:28480683",
+          "PMID:28155026",
+          "PMID:19307542",
+          "PMID:16778374"
+        ],
+        "relation": [
+          "RO:0003303",
+          "RO:0003303"
+        ],
+        "relation_label": [
+          "causes condition",
+          "causes condition"
+        ],
+        "source_database": [
+          "biolink",
+          "biolink"
+        ],
+        "source_id": "HGNC:7897",
+        "target_id": "MONDO:0009757",
+        "type": "causes"
+      },
+      {
+        "ctime": [
+          1573153347.7002532
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "3ca42696305fd2d60110e24a2c55d489",
+        "predicate_id": "RO:0002326",
+        "publications": [],
+        "relation": [
+          "RO:0004013"
+        ],
+        "relation_label": [
+          "is causal germline mutation in"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:7897",
+        "target_id": "MONDO:0017663",
+        "type": "contributes_to"
+      },
+      {
+        "ctime": [
+          1573153347.7007284
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "b87e7851c47a2561865fbb328dce1afd",
+        "predicate_id": "RO:0002410",
+        "publications": [
+          "PMID:16098014",
+          "PMID:22065762",
+          "PMID:19718781",
+          "PMID:26206375",
+          "PMID:27366019",
+          "PMID:15465421",
+          "PMID:27549128",
+          "PMID:25425405",
+          "PMID:27139891",
+          "PMID:20826119",
+          "PMID:29197565",
+          "PMID:11479732",
+          "PMID:21245028",
+          "PMID:11545687",
+          "PMID:24506780",
+          "PMID:4795418",
+          "PMID:20718790",
+          "PMID:11754101",
+          "PMID:26338816",
+          "PMID:20521171",
+          "PMID:29100954",
+          "PMID:17989072",
+          "PMID:18216017",
+          "PMID:22750297",
+          "PMID:25326637",
+          "PMID:10480349",
+          "PMID:9211849",
+          "PMID:23433426",
+          "PMID:26939636",
+          "PMID:27193329",
+          "PMID:9211850",
+          "PMID:25149939",
+          "PMID:16126423",
+          "PMID:12205649",
+          "PMID:9634529",
+          "PMID:25637190",
+          "PMID:11349231",
+          "PMID:23593294",
+          "PMID:23146215",
+          "PMID:16138904",
+          "PMID:22476655",
+          "PMID:12719428",
+          "PMID:26666848",
+          "PMID:23427322",
+          "PMID:16720792",
+          "PMID:10521297",
+          "PMID:19900398",
+          "PMID:23453666",
+          "PMID:28167839",
+          "PMID:24001525",
+          "PMID:19252935",
+          "PMID:24767253",
+          "PMID:12554680",
+          "PMID:10521290",
+          "PMID:17160617",
+          "PMID:27238017",
+          "PMID:19013089",
+          "PMID:26108224",
+          "PMID:11333381",
+          "PMID:27900365",
+          "PMID:25131710",
+          "PMID:28222799",
+          "PMID:24676439",
+          "PMID:23653225",
+          "PMID:28193631",
+          "PMID:23430855",
+          "PMID:11182931",
+          "PMID:12401890",
+          "PMID:26981555",
+          "PMID:15459971",
+          "PMID:19206179",
+          "PMID:15130691",
+          "PMID:27959697",
+          "PMID:15596783",
+          "PMID:23773996",
+          "PMID:19744920",
+          "PMID:19223215",
+          "PMID:23142039",
+          "PMID:24915861",
+          "PMID:22326530",
+          "PMID:25349751",
+          "PMID:22704015",
+          "PMID:24570279",
+          "PMID:9927649",
+          "PMID:25764212",
+          "PMID:24386122",
+          "PMID:27581084",
+          "PMID:26937389",
+          "PMID:17003072",
+          "PMID:25236789",
+          "PMID:12955717",
+          "PMID:27378690",
+          "PMID:26984608",
+          "PMID:27706244",
+          "PMID:19609713",
+          "PMID:3378364",
+          "PMID:28802248",
+          "PMID:26019327",
+          "PMID:15774455",
+          "PMID:12408188",
+          "PMID:23774949",
+          "PMID:22505584",
+          "PMID:28130309",
+          "PMID:12974729",
+          "PMID:22676771",
+          "PMID:28480683",
+          "PMID:28155026",
+          "PMID:19307542",
+          "PMID:16778374"
+        ],
+        "relation": [
+          "RO:0003303"
+        ],
+        "relation_label": [
+          "causes condition"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:7897",
+        "target_id": "MONDO:0017663",
+        "type": "causes"
+      },
+      {
+        "ctime": [
+          1573153405.5871172,
+          1572909411.90239
+        ],
+        "edge_source": [
+          "pharos.disease_get_gene",
+          "pharos.gene_get_disease"
+        ],
+        "id": "ef10ec35cc79bf0032b54f353fbfd715",
+        "predicate_id": "NCIT:R176",
+        "publications": [],
+        "relation": [
+          "PHAROS:gene_involved",
+          "PHAROS:gene_involved"
+        ],
+        "relation_label": [
+          "gene_involved",
+          "gene_involved"
+        ],
+        "source_database": [
+          "pharos",
+          "pharos"
+        ],
+        "source_id": "MONDO:0011719",
+        "target_id": "HGNC:7897",
+        "type": "disease_to_gene_association"
+      },
+      {
+        "ctime": [
+          1573153406.0724936
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "2029951f606490ff949467191cbc8082",
+        "predicate_id": "RO:0002326",
+        "publications": [],
+        "relation": [
+          "RO:0004013"
+        ],
+        "relation_label": [
+          "is causal germline mutation in"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:7897",
+        "target_id": "MONDO:0002525",
+        "type": "contributes_to"
+      },
+      {
+        "ctime": [
+          1573153406.0729194
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "f965081529979666a5e30929c2fa689c",
+        "predicate_id": "RO:0002410",
+        "publications": [
+          "PMID:16098014",
+          "PMID:22065762",
+          "PMID:19718781",
+          "PMID:26206375",
+          "PMID:27366019",
+          "PMID:15465421",
+          "PMID:27549128",
+          "PMID:25425405",
+          "PMID:27139891",
+          "PMID:20826119",
+          "PMID:29197565",
+          "PMID:11479732",
+          "PMID:21245028",
+          "PMID:11545687",
+          "PMID:24506780",
+          "PMID:4795418",
+          "PMID:20718790",
+          "PMID:11754101",
+          "PMID:26338816",
+          "PMID:20521171",
+          "PMID:29100954",
+          "PMID:17989072",
+          "PMID:18216017",
+          "PMID:22750297",
+          "PMID:25326637",
+          "PMID:10480349",
+          "PMID:9211849",
+          "PMID:23433426",
+          "PMID:26939636",
+          "PMID:27193329",
+          "PMID:9211850",
+          "PMID:25149939",
+          "PMID:16126423",
+          "PMID:12205649",
+          "PMID:9634529",
+          "PMID:25637190",
+          "PMID:11349231",
+          "PMID:23593294",
+          "PMID:23146215",
+          "PMID:16138904",
+          "PMID:22476655",
+          "PMID:12719428",
+          "PMID:26666848",
+          "PMID:23427322",
+          "PMID:16720792",
+          "PMID:10521297",
+          "PMID:19900398",
+          "PMID:23453666",
+          "PMID:28167839",
+          "PMID:24001525",
+          "PMID:19252935",
+          "PMID:24767253",
+          "PMID:12554680",
+          "PMID:10521290",
+          "PMID:17160617",
+          "PMID:27238017",
+          "PMID:19013089",
+          "PMID:26108224",
+          "PMID:11333381",
+          "PMID:27900365",
+          "PMID:25131710",
+          "PMID:28222799",
+          "PMID:24676439",
+          "PMID:23653225",
+          "PMID:28193631",
+          "PMID:23430855",
+          "PMID:11182931",
+          "PMID:12401890",
+          "PMID:26981555",
+          "PMID:15459971",
+          "PMID:19206179",
+          "PMID:15130691",
+          "PMID:27959697",
+          "PMID:15596783",
+          "PMID:23773996",
+          "PMID:19744920",
+          "PMID:19223215",
+          "PMID:23142039",
+          "PMID:24915861",
+          "PMID:22326530",
+          "PMID:25349751",
+          "PMID:22704015",
+          "PMID:24570279",
+          "PMID:9927649",
+          "PMID:25764212",
+          "PMID:24386122",
+          "PMID:27581084",
+          "PMID:26937389",
+          "PMID:17003072",
+          "PMID:25236789",
+          "PMID:12955717",
+          "PMID:27378690",
+          "PMID:26984608",
+          "PMID:27706244",
+          "PMID:19609713",
+          "PMID:3378364",
+          "PMID:28802248",
+          "PMID:26019327",
+          "PMID:15774455",
+          "PMID:12408188",
+          "PMID:23774949",
+          "PMID:22505584",
+          "PMID:28130309",
+          "PMID:12974729",
+          "PMID:22676771",
+          "PMID:28480683",
+          "PMID:28155026",
+          "PMID:19307542",
+          "PMID:16778374"
+        ],
+        "relation": [
+          "RO:0003303"
+        ],
+        "relation_label": [
+          "causes condition"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:7897",
+        "target_id": "MONDO:0002525",
+        "type": "causes"
+      },
+      {
+        "ctime": [
+          1573153453.9891381
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "cf90e39f3e7d80d84595bf7bd64ee58b",
+        "predicate_id": "RO:0002326",
+        "publications": [],
+        "relation": [
+          "RO:0003304"
+        ],
+        "relation_label": [
+          "contributes to condition"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:16361",
+        "target_id": "MONDO:0000275",
+        "type": "contributes_to"
+      },
+      {
+        "ctime": [
+          1573153453.9928987
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "d1ad281c8d8ccc993e4b03a0f75609f9",
+        "predicate_id": "RO:0002326",
+        "publications": [],
+        "relation": [
+          "RO:0004013"
+        ],
+        "relation_label": [
+          "is causal germline mutation in"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:30922",
+        "target_id": "MONDO:0000275",
+        "type": "contributes_to"
+      },
+      {
+        "ctime": [
+          1573153453.9929786
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "51fcce977d8c8be6b4ebae89175aa55c",
+        "predicate_id": "RO:0002410",
+        "publications": [
+          "PMID:21937992",
+          "PMID:23773660"
+        ],
+        "relation": [
+          "RO:0003303"
+        ],
+        "relation_label": [
+          "causes condition"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:30922",
+        "target_id": "MONDO:0000275",
+        "type": "causes"
+      },
+      {
+        "ctime": [
+          1573153454.115778
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "7e0898c6e19f07399e41642096b1aab9",
+        "predicate_id": "RO:0002326",
+        "publications": [],
+        "relation": [
+          "RO:0004013"
+        ],
+        "relation_label": [
+          "is causal germline mutation in"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:7897",
+        "target_id": "MONDO:0000275",
+        "type": "contributes_to"
+      },
+      {
+        "ctime": [
+          1573153454.1161873
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "a54f731ce79a51c55ed9d2c7a4ba163e",
+        "predicate_id": "RO:0002410",
+        "publications": [
+          "PMID:16098014",
+          "PMID:22065762",
+          "PMID:19718781",
+          "PMID:26206375",
+          "PMID:27366019",
+          "PMID:15465421",
+          "PMID:27549128",
+          "PMID:25425405",
+          "PMID:27139891",
+          "PMID:20826119",
+          "PMID:29197565",
+          "PMID:11479732",
+          "PMID:21245028",
+          "PMID:11545687",
+          "PMID:24506780",
+          "PMID:4795418",
+          "PMID:20718790",
+          "PMID:11754101",
+          "PMID:26338816",
+          "PMID:20521171",
+          "PMID:29100954",
+          "PMID:17989072",
+          "PMID:18216017",
+          "PMID:22750297",
+          "PMID:25326637",
+          "PMID:10480349",
+          "PMID:9211849",
+          "PMID:23433426",
+          "PMID:26939636",
+          "PMID:27193329",
+          "PMID:9211850",
+          "PMID:25149939",
+          "PMID:16126423",
+          "PMID:12205649",
+          "PMID:9634529",
+          "PMID:25637190",
+          "PMID:11349231",
+          "PMID:23593294",
+          "PMID:23146215",
+          "PMID:16138904",
+          "PMID:22476655",
+          "PMID:12719428",
+          "PMID:26666848",
+          "PMID:23427322",
+          "PMID:16720792",
+          "PMID:10521297",
+          "PMID:19900398",
+          "PMID:23453666",
+          "PMID:28167839",
+          "PMID:24001525",
+          "PMID:19252935",
+          "PMID:24767253",
+          "PMID:12554680",
+          "PMID:10521290",
+          "PMID:17160617",
+          "PMID:27238017",
+          "PMID:19013089",
+          "PMID:26108224",
+          "PMID:11333381",
+          "PMID:27900365",
+          "PMID:25131710",
+          "PMID:28222799",
+          "PMID:24676439",
+          "PMID:23653225",
+          "PMID:28193631",
+          "PMID:23430855",
+          "PMID:11182931",
+          "PMID:12401890",
+          "PMID:26981555",
+          "PMID:15459971",
+          "PMID:19206179",
+          "PMID:15130691",
+          "PMID:27959697",
+          "PMID:15596783",
+          "PMID:23773996",
+          "PMID:19744920",
+          "PMID:19223215",
+          "PMID:23142039",
+          "PMID:24915861",
+          "PMID:22326530",
+          "PMID:25349751",
+          "PMID:22704015",
+          "PMID:24570279",
+          "PMID:9927649",
+          "PMID:25764212",
+          "PMID:24386122",
+          "PMID:27581084",
+          "PMID:26937389",
+          "PMID:17003072",
+          "PMID:25236789",
+          "PMID:12955717",
+          "PMID:27378690",
+          "PMID:26984608",
+          "PMID:27706244",
+          "PMID:19609713",
+          "PMID:3378364",
+          "PMID:28802248",
+          "PMID:26019327",
+          "PMID:15774455",
+          "PMID:12408188",
+          "PMID:23774949",
+          "PMID:22505584",
+          "PMID:28130309",
+          "PMID:12974729",
+          "PMID:22676771",
+          "PMID:28480683",
+          "PMID:28155026",
+          "PMID:19307542",
+          "PMID:16778374"
+        ],
+        "relation": [
+          "RO:0003303"
+        ],
+        "relation_label": [
+          "causes condition"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:7897",
+        "target_id": "MONDO:0000275",
+        "type": "causes"
+      },
+      {
+        "ctime": [
+          1573153454.126764
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "7043c5c6d13c04acde6ffadcd1c7affa",
+        "predicate_id": "RO:0002410",
+        "publications": [
+          "PMID:15841483",
+          "PMID:12833159",
+          "PMID:11973626"
+        ],
+        "relation": [
+          "RO:0003303"
+        ],
+        "relation_label": [
+          "causes condition"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:16361",
+        "target_id": "MONDO:0000275",
+        "type": "causes"
+      },
+      {
+        "ctime": [
+          1573153490.1334023,
+          1572909411.8988168
+        ],
+        "edge_source": [
+          "pharos.disease_get_gene",
+          "pharos.gene_get_disease"
+        ],
+        "id": "7361a22b0bd99e435e77889cb8b65e97",
+        "predicate_id": "NCIT:R176",
+        "publications": [],
+        "relation": [
+          "PHAROS:gene_involved",
+          "PHAROS:gene_involved"
+        ],
+        "relation_label": [
+          "gene_involved",
+          "gene_involved"
+        ],
+        "source_database": [
+          "pharos",
+          "pharos"
+        ],
+        "source_id": "MONDO:0017719",
+        "target_id": "HGNC:7897",
+        "type": "disease_to_gene_association"
+      },
+      {
+        "ctime": [
+          1573153576.5599425
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "12ad8c1cd217e1889ac92873b23b2da9",
+        "predicate_id": "RO:0002326",
+        "publications": [],
+        "relation": [
+          "RO:0004013"
+        ],
+        "relation_label": [
+          "is causal germline mutation in"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:7897",
+        "target_id": "MONDO:0002561",
+        "type": "contributes_to"
+      },
+      {
+        "ctime": [
+          1573153576.560335
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "2981a9f1d0498b3d0bd251238043d8a6",
+        "predicate_id": "RO:0002410",
+        "publications": [
+          "PMID:16098014",
+          "PMID:22065762",
+          "PMID:19718781",
+          "PMID:26206375",
+          "PMID:27366019",
+          "PMID:15465421",
+          "PMID:27549128",
+          "PMID:25425405",
+          "PMID:27139891",
+          "PMID:20826119",
+          "PMID:29197565",
+          "PMID:11479732",
+          "PMID:21245028",
+          "PMID:11545687",
+          "PMID:24506780",
+          "PMID:4795418",
+          "PMID:20718790",
+          "PMID:11754101",
+          "PMID:26338816",
+          "PMID:20521171",
+          "PMID:29100954",
+          "PMID:17989072",
+          "PMID:18216017",
+          "PMID:22750297",
+          "PMID:25326637",
+          "PMID:10480349",
+          "PMID:9211849",
+          "PMID:23433426",
+          "PMID:26939636",
+          "PMID:27193329",
+          "PMID:9211850",
+          "PMID:25149939",
+          "PMID:16126423",
+          "PMID:12205649",
+          "PMID:9634529",
+          "PMID:25637190",
+          "PMID:11349231",
+          "PMID:23593294",
+          "PMID:23146215",
+          "PMID:16138904",
+          "PMID:22476655",
+          "PMID:12719428",
+          "PMID:26666848",
+          "PMID:23427322",
+          "PMID:16720792",
+          "PMID:10521297",
+          "PMID:19900398",
+          "PMID:23453666",
+          "PMID:28167839",
+          "PMID:24001525",
+          "PMID:19252935",
+          "PMID:24767253",
+          "PMID:12554680",
+          "PMID:10521290",
+          "PMID:17160617",
+          "PMID:27238017",
+          "PMID:19013089",
+          "PMID:26108224",
+          "PMID:11333381",
+          "PMID:27900365",
+          "PMID:25131710",
+          "PMID:28222799",
+          "PMID:24676439",
+          "PMID:23653225",
+          "PMID:28193631",
+          "PMID:23430855",
+          "PMID:11182931",
+          "PMID:12401890",
+          "PMID:26981555",
+          "PMID:15459971",
+          "PMID:19206179",
+          "PMID:15130691",
+          "PMID:27959697",
+          "PMID:15596783",
+          "PMID:23773996",
+          "PMID:19744920",
+          "PMID:19223215",
+          "PMID:23142039",
+          "PMID:24915861",
+          "PMID:22326530",
+          "PMID:25349751",
+          "PMID:22704015",
+          "PMID:24570279",
+          "PMID:9927649",
+          "PMID:25764212",
+          "PMID:24386122",
+          "PMID:27581084",
+          "PMID:26937389",
+          "PMID:17003072",
+          "PMID:25236789",
+          "PMID:12955717",
+          "PMID:27378690",
+          "PMID:26984608",
+          "PMID:27706244",
+          "PMID:19609713",
+          "PMID:3378364",
+          "PMID:28802248",
+          "PMID:26019327",
+          "PMID:15774455",
+          "PMID:12408188",
+          "PMID:23774949",
+          "PMID:22505584",
+          "PMID:28130309",
+          "PMID:12974729",
+          "PMID:22676771",
+          "PMID:28480683",
+          "PMID:28155026",
+          "PMID:19307542",
+          "PMID:16778374"
+        ],
+        "relation": [
+          "RO:0003303"
+        ],
+        "relation_label": [
+          "causes condition"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:7897",
+        "target_id": "MONDO:0002561",
+        "type": "causes"
+      },
+      {
+        "ctime": [
+          1573154354.018858,
+          1572887879.0432606
+        ],
+        "edge_source": [
+          "pharos.disease_get_gene",
+          "pharos.gene_get_disease"
+        ],
+        "id": "6b56f24f52a2dbc161cb3feeffe32d4a",
+        "predicate_id": "NCIT:R176",
+        "publications": [],
+        "relation": [
+          "PHAROS:gene_involved",
+          "PHAROS:gene_involved"
+        ],
+        "relation_label": [
+          "gene_involved",
+          "gene_involved"
+        ],
+        "source_database": [
+          "pharos",
+          "pharos"
+        ],
+        "source_id": "MONDO:0010383",
+        "target_id": "HGNC:4669",
+        "type": "disease_to_gene_association"
+      },
+      {
+        "ctime": [
+          1573154660.5158348,
+          1572931709.1176531
+        ],
+        "edge_source": [
+          "pharos.disease_get_gene",
+          "pharos.gene_get_disease"
+        ],
+        "id": "d9dc1b3f3972ff4a3cf0ebfad122c5c8",
+        "predicate_id": "NCIT:R176",
+        "publications": [],
+        "relation": [
+          "PHAROS:gene_involved",
+          "PHAROS:gene_involved"
+        ],
+        "relation_label": [
+          "gene_involved",
+          "gene_involved"
+        ],
+        "source_database": [
+          "pharos",
+          "pharos"
+        ],
+        "source_id": "MONDO:0010576",
+        "target_id": "HGNC:16361",
+        "type": "disease_to_gene_association"
+      },
+      {
+        "ctime": [
+          1573155386.0607734,
+          1572890268.9769835
+        ],
+        "edge_source": [
+          "pharos.disease_get_gene",
+          "pharos.gene_get_disease"
+        ],
+        "id": "21ddd2f1adf8223c708b3ca60ac4e85e",
+        "predicate_id": "NCIT:R176",
+        "publications": [],
+        "relation": [
+          "PHAROS:gene_involved",
+          "PHAROS:gene_involved"
+        ],
+        "relation_label": [
+          "gene_involved",
+          "gene_involved"
+        ],
+        "source_database": [
+          "pharos",
+          "pharos"
+        ],
+        "source_id": "MONDO:0005737",
+        "target_id": "HGNC:29249",
+        "type": "disease_to_gene_association"
+      },
+      {
+        "ctime": [
+          1573155386.061005,
+          1572887879.0431411
+        ],
+        "edge_source": [
+          "pharos.disease_get_gene",
+          "pharos.gene_get_disease"
+        ],
+        "id": "2fab55008b84688f4203f10ca8db68e6",
+        "predicate_id": "NCIT:R176",
+        "publications": [],
+        "relation": [
+          "PHAROS:gene_involved",
+          "PHAROS:gene_involved"
+        ],
+        "relation_label": [
+          "gene_involved",
+          "gene_involved"
+        ],
+        "source_database": [
+          "pharos",
+          "pharos"
+        ],
+        "source_id": "MONDO:0005737",
+        "target_id": "HGNC:4669",
+        "type": "disease_to_gene_association"
+      },
+      {
+        "ctime": [
+          1573155386.0610888,
+          1572914332.8442817
+        ],
+        "edge_source": [
+          "pharos.disease_get_gene",
+          "pharos.gene_get_disease"
+        ],
+        "id": "f8cfff67b05fe83baf3f51332921197e",
+        "predicate_id": "NCIT:R176",
+        "publications": [],
+        "relation": [
+          "PHAROS:gene_involved",
+          "PHAROS:gene_involved"
+        ],
+        "relation_label": [
+          "gene_involved",
+          "gene_involved"
+        ],
+        "source_database": [
+          "pharos",
+          "pharos"
+        ],
+        "source_id": "MONDO:0005737",
+        "target_id": "HGNC:24867",
+        "type": "disease_to_gene_association"
+      },
+      {
+        "ctime": [
+          1573155386.0612833,
+          1572916740.9685495
+        ],
+        "edge_source": [
+          "pharos.disease_get_gene",
+          "pharos.gene_get_disease"
+        ],
+        "id": "b4835feac457fe2140e3f5394cd09290",
+        "predicate_id": "NCIT:R176",
+        "publications": [],
+        "relation": [
+          "PHAROS:gene_involved",
+          "PHAROS:gene_involved"
+        ],
+        "relation_label": [
+          "gene_involved",
+          "gene_involved"
+        ],
+        "source_database": [
+          "pharos",
+          "pharos"
+        ],
+        "source_id": "MONDO:0005737",
+        "target_id": "HGNC:30922",
+        "type": "disease_to_gene_association"
+      },
+      {
+        "ctime": [
+          1573155386.0613642,
+          1572919447.3174157
+        ],
+        "edge_source": [
+          "pharos.disease_get_gene",
+          "pharos.gene_get_disease"
+        ],
+        "id": "39be31d4e134546a43882d14f945aeec",
+        "predicate_id": "NCIT:R176",
+        "publications": [],
+        "relation": [
+          "PHAROS:gene_involved",
+          "PHAROS:gene_involved"
+        ],
+        "relation_label": [
+          "gene_involved",
+          "gene_involved"
+        ],
+        "source_database": [
+          "pharos",
+          "pharos"
+        ],
+        "source_id": "MONDO:0005737",
+        "target_id": "HGNC:20818",
+        "type": "disease_to_gene_association"
+      },
+      {
+        "ctime": [
+          1573155386.0614562,
+          1572909411.898535
+        ],
+        "edge_source": [
+          "pharos.disease_get_gene",
+          "pharos.gene_get_disease"
+        ],
+        "id": "5579d0ec3e69cf5bd79fd643942d8536",
+        "predicate_id": "NCIT:R176",
+        "publications": [],
+        "relation": [
+          "PHAROS:gene_involved",
+          "PHAROS:gene_involved"
+        ],
+        "relation_label": [
+          "gene_involved",
+          "gene_involved"
+        ],
+        "source_database": [
+          "pharos",
+          "pharos"
+        ],
+        "source_id": "MONDO:0005737",
+        "target_id": "HGNC:7897",
+        "type": "disease_to_gene_association"
+      },
+      {
+        "ctime": [
+          1573155386.0615447,
+          1572931873.8105574
+        ],
+        "edge_source": [
+          "pharos.disease_get_gene",
+          "pharos.gene_get_disease"
+        ],
+        "id": "9d176db36fcfb9f359c52062767faa7d",
+        "predicate_id": "NCIT:R176",
+        "publications": [],
+        "relation": [
+          "PHAROS:gene_involved",
+          "PHAROS:gene_involved"
+        ],
+        "relation_label": [
+          "gene_involved",
+          "gene_involved"
+        ],
+        "source_database": [
+          "pharos",
+          "pharos"
+        ],
+        "source_id": "MONDO:0005737",
+        "target_id": "HGNC:17770",
+        "type": "disease_to_gene_association"
+      },
+      {
+        "ctime": [
+          1573155386.0617359,
+          1572923055.3116145
+        ],
+        "edge_source": [
+          "pharos.disease_get_gene",
+          "pharos.gene_get_disease"
+        ],
+        "id": "707a6bbe3f735db98e9aa997ef3f6f41",
+        "predicate_id": "NCIT:R176",
+        "publications": [],
+        "relation": [
+          "PHAROS:gene_involved",
+          "PHAROS:gene_involved"
+        ],
+        "relation_label": [
+          "gene_involved",
+          "gene_involved"
+        ],
+        "source_database": [
+          "pharos",
+          "pharos"
+        ],
+        "source_id": "MONDO:0005737",
+        "target_id": "HGNC:13236",
+        "type": "disease_to_gene_association"
+      },
+      {
+        "ctime": [
+          1573155386.061897,
+          1572931709.1174293
+        ],
+        "edge_source": [
+          "pharos.disease_get_gene",
+          "pharos.gene_get_disease"
+        ],
+        "id": "f30686d3a5edb8d62e319fa34920fec9",
+        "predicate_id": "NCIT:R176",
+        "publications": [],
+        "relation": [
+          "PHAROS:gene_involved",
+          "PHAROS:gene_involved"
+        ],
+        "relation_label": [
+          "gene_involved",
+          "gene_involved"
+        ],
+        "source_database": [
+          "pharos",
+          "pharos"
+        ],
+        "source_id": "MONDO:0005737",
+        "target_id": "HGNC:16361",
+        "type": "disease_to_gene_association"
+      },
+      {
+        "ctime": [
+          1573155597.1744382
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "bbdfe8de23ccd5bb27e004129b80959a",
+        "predicate_id": "RO:0002326",
+        "publications": [],
+        "relation": [
+          "RO:0003304"
+        ],
+        "relation_label": [
+          "contributes to condition"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:16361",
+        "target_id": "MONDO:0023603",
+        "type": "contributes_to"
+      },
+      {
+        "ctime": [
+          1573155597.256949
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "94b610df333552b2291c81385c58b8d6",
+        "predicate_id": "RO:0002326",
+        "publications": [],
+        "relation": [
+          "RO:0004013"
+        ],
+        "relation_label": [
+          "is causal germline mutation in"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:7897",
+        "target_id": "MONDO:0023603",
+        "type": "contributes_to"
+      },
+      {
+        "ctime": [
+          1573155597.2573426
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "ceeead34232032edccaa0e482f149030",
+        "predicate_id": "RO:0002410",
+        "publications": [
+          "PMID:16098014",
+          "PMID:22065762",
+          "PMID:19718781",
+          "PMID:26206375",
+          "PMID:27366019",
+          "PMID:15465421",
+          "PMID:27549128",
+          "PMID:25425405",
+          "PMID:27139891",
+          "PMID:20826119",
+          "PMID:29197565",
+          "PMID:11479732",
+          "PMID:21245028",
+          "PMID:11545687",
+          "PMID:24506780",
+          "PMID:4795418",
+          "PMID:20718790",
+          "PMID:11754101",
+          "PMID:26338816",
+          "PMID:20521171",
+          "PMID:29100954",
+          "PMID:17989072",
+          "PMID:18216017",
+          "PMID:22750297",
+          "PMID:25326637",
+          "PMID:10480349",
+          "PMID:9211849",
+          "PMID:23433426",
+          "PMID:26939636",
+          "PMID:27193329",
+          "PMID:9211850",
+          "PMID:25149939",
+          "PMID:16126423",
+          "PMID:12205649",
+          "PMID:9634529",
+          "PMID:25637190",
+          "PMID:11349231",
+          "PMID:23593294",
+          "PMID:23146215",
+          "PMID:16138904",
+          "PMID:22476655",
+          "PMID:12719428",
+          "PMID:26666848",
+          "PMID:23427322",
+          "PMID:16720792",
+          "PMID:10521297",
+          "PMID:19900398",
+          "PMID:23453666",
+          "PMID:28167839",
+          "PMID:24001525",
+          "PMID:19252935",
+          "PMID:24767253",
+          "PMID:12554680",
+          "PMID:10521290",
+          "PMID:17160617",
+          "PMID:27238017",
+          "PMID:19013089",
+          "PMID:26108224",
+          "PMID:11333381",
+          "PMID:27900365",
+          "PMID:25131710",
+          "PMID:28222799",
+          "PMID:24676439",
+          "PMID:23653225",
+          "PMID:28193631",
+          "PMID:23430855",
+          "PMID:11182931",
+          "PMID:12401890",
+          "PMID:26981555",
+          "PMID:15459971",
+          "PMID:19206179",
+          "PMID:15130691",
+          "PMID:27959697",
+          "PMID:15596783",
+          "PMID:23773996",
+          "PMID:19744920",
+          "PMID:19223215",
+          "PMID:23142039",
+          "PMID:24915861",
+          "PMID:22326530",
+          "PMID:25349751",
+          "PMID:22704015",
+          "PMID:24570279",
+          "PMID:9927649",
+          "PMID:25764212",
+          "PMID:24386122",
+          "PMID:27581084",
+          "PMID:26937389",
+          "PMID:17003072",
+          "PMID:25236789",
+          "PMID:12955717",
+          "PMID:27378690",
+          "PMID:26984608",
+          "PMID:27706244",
+          "PMID:19609713",
+          "PMID:3378364",
+          "PMID:28802248",
+          "PMID:26019327",
+          "PMID:15774455",
+          "PMID:12408188",
+          "PMID:23774949",
+          "PMID:22505584",
+          "PMID:28130309",
+          "PMID:12974729",
+          "PMID:22676771",
+          "PMID:28480683",
+          "PMID:28155026",
+          "PMID:19307542",
+          "PMID:16778374"
+        ],
+        "relation": [
+          "RO:0003303"
+        ],
+        "relation_label": [
+          "causes condition"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:7897",
+        "target_id": "MONDO:0023603",
+        "type": "causes"
+      },
+      {
+        "ctime": [
+          1573155597.2648575
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "6d39c08044c1d4fc303b5fccebfadc0f",
+        "predicate_id": "RO:0002410",
+        "publications": [
+          "PMID:17171570"
+        ],
+        "relation": [
+          "RO:0003303"
+        ],
+        "relation_label": [
+          "causes condition"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:16361",
+        "target_id": "MONDO:0023603",
+        "type": "causes"
+      },
+      {
+        "ctime": [
+          1573155772.16591
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "4acb507be781eaecf2d588b5963a0129",
+        "predicate_id": "RO:0002326",
+        "publications": [],
+        "relation": [
+          "RO:0004013"
+        ],
+        "relation_label": [
+          "is causal germline mutation in"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:7897",
+        "target_id": "MONDO:0015547",
+        "type": "contributes_to"
+      },
+      {
+        "ctime": [
+          1573155772.1663024
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "0a45559c62f3b853d786f19162b9949f",
+        "predicate_id": "RO:0002410",
+        "publications": [
+          "PMID:16098014",
+          "PMID:22065762",
+          "PMID:19718781",
+          "PMID:26206375",
+          "PMID:27366019",
+          "PMID:15465421",
+          "PMID:27549128",
+          "PMID:25425405",
+          "PMID:27139891",
+          "PMID:20826119",
+          "PMID:29197565",
+          "PMID:11479732",
+          "PMID:21245028",
+          "PMID:11545687",
+          "PMID:24506780",
+          "PMID:4795418",
+          "PMID:20718790",
+          "PMID:11754101",
+          "PMID:26338816",
+          "PMID:20521171",
+          "PMID:29100954",
+          "PMID:17989072",
+          "PMID:18216017",
+          "PMID:22750297",
+          "PMID:25326637",
+          "PMID:10480349",
+          "PMID:9211849",
+          "PMID:23433426",
+          "PMID:26939636",
+          "PMID:27193329",
+          "PMID:9211850",
+          "PMID:25149939",
+          "PMID:16126423",
+          "PMID:12205649",
+          "PMID:9634529",
+          "PMID:25637190",
+          "PMID:11349231",
+          "PMID:23593294",
+          "PMID:23146215",
+          "PMID:16138904",
+          "PMID:22476655",
+          "PMID:12719428",
+          "PMID:26666848",
+          "PMID:23427322",
+          "PMID:16720792",
+          "PMID:10521297",
+          "PMID:19900398",
+          "PMID:23453666",
+          "PMID:28167839",
+          "PMID:24001525",
+          "PMID:19252935",
+          "PMID:24767253",
+          "PMID:12554680",
+          "PMID:10521290",
+          "PMID:17160617",
+          "PMID:27238017",
+          "PMID:19013089",
+          "PMID:26108224",
+          "PMID:11333381",
+          "PMID:27900365",
+          "PMID:25131710",
+          "PMID:28222799",
+          "PMID:24676439",
+          "PMID:23653225",
+          "PMID:28193631",
+          "PMID:23430855",
+          "PMID:11182931",
+          "PMID:12401890",
+          "PMID:26981555",
+          "PMID:15459971",
+          "PMID:19206179",
+          "PMID:15130691",
+          "PMID:27959697",
+          "PMID:15596783",
+          "PMID:23773996",
+          "PMID:19744920",
+          "PMID:19223215",
+          "PMID:23142039",
+          "PMID:24915861",
+          "PMID:22326530",
+          "PMID:25349751",
+          "PMID:22704015",
+          "PMID:24570279",
+          "PMID:9927649",
+          "PMID:25764212",
+          "PMID:24386122",
+          "PMID:27581084",
+          "PMID:26937389",
+          "PMID:17003072",
+          "PMID:25236789",
+          "PMID:12955717",
+          "PMID:27378690",
+          "PMID:26984608",
+          "PMID:27706244",
+          "PMID:19609713",
+          "PMID:3378364",
+          "PMID:28802248",
+          "PMID:26019327",
+          "PMID:15774455",
+          "PMID:12408188",
+          "PMID:23774949",
+          "PMID:22505584",
+          "PMID:28130309",
+          "PMID:12974729",
+          "PMID:22676771",
+          "PMID:28480683",
+          "PMID:28155026",
+          "PMID:19307542",
+          "PMID:16778374"
+        ],
+        "relation": [
+          "RO:0003303"
+        ],
+        "relation_label": [
+          "causes condition"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:7897",
+        "target_id": "MONDO:0015547",
+        "type": "causes"
+      },
+      {
+        "ctime": [
+          1573155914.3893104
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "f0c58954ab424612138f2bb6b5f33d54",
+        "predicate_id": "RO:0002326",
+        "publications": [],
+        "relation": [
+          "RO:0004013"
+        ],
+        "relation_label": [
+          "is causal germline mutation in"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:7897",
+        "target_id": "MONDO:0018299",
+        "type": "contributes_to"
+      },
+      {
+        "ctime": [
+          1573155914.3896809
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "b15043dcf00b641e9ab65377f044abf2",
+        "predicate_id": "RO:0002410",
+        "publications": [
+          "PMID:16098014",
+          "PMID:22065762",
+          "PMID:19718781",
+          "PMID:26206375",
+          "PMID:27366019",
+          "PMID:15465421",
+          "PMID:27549128",
+          "PMID:25425405",
+          "PMID:27139891",
+          "PMID:20826119",
+          "PMID:29197565",
+          "PMID:11479732",
+          "PMID:21245028",
+          "PMID:11545687",
+          "PMID:24506780",
+          "PMID:4795418",
+          "PMID:20718790",
+          "PMID:11754101",
+          "PMID:26338816",
+          "PMID:20521171",
+          "PMID:29100954",
+          "PMID:17989072",
+          "PMID:18216017",
+          "PMID:22750297",
+          "PMID:25326637",
+          "PMID:10480349",
+          "PMID:9211849",
+          "PMID:23433426",
+          "PMID:26939636",
+          "PMID:27193329",
+          "PMID:9211850",
+          "PMID:25149939",
+          "PMID:16126423",
+          "PMID:12205649",
+          "PMID:9634529",
+          "PMID:25637190",
+          "PMID:11349231",
+          "PMID:23593294",
+          "PMID:23146215",
+          "PMID:16138904",
+          "PMID:22476655",
+          "PMID:12719428",
+          "PMID:26666848",
+          "PMID:23427322",
+          "PMID:16720792",
+          "PMID:10521297",
+          "PMID:19900398",
+          "PMID:23453666",
+          "PMID:28167839",
+          "PMID:24001525",
+          "PMID:19252935",
+          "PMID:24767253",
+          "PMID:12554680",
+          "PMID:10521290",
+          "PMID:17160617",
+          "PMID:27238017",
+          "PMID:19013089",
+          "PMID:26108224",
+          "PMID:11333381",
+          "PMID:27900365",
+          "PMID:25131710",
+          "PMID:28222799",
+          "PMID:24676439",
+          "PMID:23653225",
+          "PMID:28193631",
+          "PMID:23430855",
+          "PMID:11182931",
+          "PMID:12401890",
+          "PMID:26981555",
+          "PMID:15459971",
+          "PMID:19206179",
+          "PMID:15130691",
+          "PMID:27959697",
+          "PMID:15596783",
+          "PMID:23773996",
+          "PMID:19744920",
+          "PMID:19223215",
+          "PMID:23142039",
+          "PMID:24915861",
+          "PMID:22326530",
+          "PMID:25349751",
+          "PMID:22704015",
+          "PMID:24570279",
+          "PMID:9927649",
+          "PMID:25764212",
+          "PMID:24386122",
+          "PMID:27581084",
+          "PMID:26937389",
+          "PMID:17003072",
+          "PMID:25236789",
+          "PMID:12955717",
+          "PMID:27378690",
+          "PMID:26984608",
+          "PMID:27706244",
+          "PMID:19609713",
+          "PMID:3378364",
+          "PMID:28802248",
+          "PMID:26019327",
+          "PMID:15774455",
+          "PMID:12408188",
+          "PMID:23774949",
+          "PMID:22505584",
+          "PMID:28130309",
+          "PMID:12974729",
+          "PMID:22676771",
+          "PMID:28480683",
+          "PMID:28155026",
+          "PMID:19307542",
+          "PMID:16778374"
+        ],
+        "relation": [
+          "RO:0003303"
+        ],
+        "relation_label": [
+          "causes condition"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:7897",
+        "target_id": "MONDO:0018299",
+        "type": "causes"
+      },
+      {
+        "ctime": [
+          1573155972.3576548
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "7856edba25fc639d9c9c3f7e9e731334",
+        "predicate_id": "RO:0002326",
+        "publications": [],
+        "relation": [
+          "RO:0004013"
+        ],
+        "relation_label": [
+          "is causal germline mutation in"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:7897",
+        "target_id": "MONDO:0015653",
+        "type": "contributes_to"
+      },
+      {
+        "ctime": [
+          1573155972.3581479
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "674187fabae5f0149ab9ffeb51a6f9fe",
+        "predicate_id": "RO:0002410",
+        "publications": [
+          "PMID:16098014",
+          "PMID:22065762",
+          "PMID:19718781",
+          "PMID:26206375",
+          "PMID:27366019",
+          "PMID:15465421",
+          "PMID:27549128",
+          "PMID:25425405",
+          "PMID:27139891",
+          "PMID:20826119",
+          "PMID:29197565",
+          "PMID:11479732",
+          "PMID:21245028",
+          "PMID:11545687",
+          "PMID:24506780",
+          "PMID:4795418",
+          "PMID:20718790",
+          "PMID:11754101",
+          "PMID:26338816",
+          "PMID:20521171",
+          "PMID:29100954",
+          "PMID:17989072",
+          "PMID:18216017",
+          "PMID:22750297",
+          "PMID:25326637",
+          "PMID:10480349",
+          "PMID:9211849",
+          "PMID:23433426",
+          "PMID:26939636",
+          "PMID:27193329",
+          "PMID:9211850",
+          "PMID:25149939",
+          "PMID:16126423",
+          "PMID:12205649",
+          "PMID:9634529",
+          "PMID:25637190",
+          "PMID:11349231",
+          "PMID:23593294",
+          "PMID:23146215",
+          "PMID:16138904",
+          "PMID:22476655",
+          "PMID:12719428",
+          "PMID:26666848",
+          "PMID:23427322",
+          "PMID:16720792",
+          "PMID:10521297",
+          "PMID:19900398",
+          "PMID:23453666",
+          "PMID:28167839",
+          "PMID:24001525",
+          "PMID:19252935",
+          "PMID:24767253",
+          "PMID:12554680",
+          "PMID:10521290",
+          "PMID:17160617",
+          "PMID:27238017",
+          "PMID:19013089",
+          "PMID:26108224",
+          "PMID:11333381",
+          "PMID:27900365",
+          "PMID:25131710",
+          "PMID:28222799",
+          "PMID:24676439",
+          "PMID:23653225",
+          "PMID:28193631",
+          "PMID:23430855",
+          "PMID:11182931",
+          "PMID:12401890",
+          "PMID:26981555",
+          "PMID:15459971",
+          "PMID:19206179",
+          "PMID:15130691",
+          "PMID:27959697",
+          "PMID:15596783",
+          "PMID:23773996",
+          "PMID:19744920",
+          "PMID:19223215",
+          "PMID:23142039",
+          "PMID:24915861",
+          "PMID:22326530",
+          "PMID:25349751",
+          "PMID:22704015",
+          "PMID:24570279",
+          "PMID:9927649",
+          "PMID:25764212",
+          "PMID:24386122",
+          "PMID:27581084",
+          "PMID:26937389",
+          "PMID:17003072",
+          "PMID:25236789",
+          "PMID:12955717",
+          "PMID:27378690",
+          "PMID:26984608",
+          "PMID:27706244",
+          "PMID:19609713",
+          "PMID:3378364",
+          "PMID:28802248",
+          "PMID:26019327",
+          "PMID:15774455",
+          "PMID:12408188",
+          "PMID:23774949",
+          "PMID:22505584",
+          "PMID:28130309",
+          "PMID:12974729",
+          "PMID:22676771",
+          "PMID:28480683",
+          "PMID:28155026",
+          "PMID:19307542",
+          "PMID:16778374"
+        ],
+        "relation": [
+          "RO:0003303"
+        ],
+        "relation_label": [
+          "causes condition"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:7897",
+        "target_id": "MONDO:0015653",
+        "type": "causes"
+      },
+      {
+        "ctime": [
+          1573155808.7696447
+        ],
+        "edge_source": [
+          "pharos.disease_get_gene"
+        ],
+        "id": "46345bb5090e444a54fce30d78ac7beb",
+        "predicate_id": "NCIT:R176",
+        "publications": [],
+        "relation": [
+          "PHAROS:gene_involved"
+        ],
+        "relation_label": [
+          "gene_involved"
+        ],
+        "source_database": [
+          "pharos"
+        ],
+        "source_id": "MONDO:0011080",
+        "target_id": "HGNC:16361",
+        "type": "disease_to_gene_association"
+      },
+      {
+        "ctime": [
+          1573156105.385078
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "2991231517de9621b906b8147adc328a",
+        "predicate_id": "RO:0002326",
+        "publications": [],
+        "relation": [
+          "RO:0004013"
+        ],
+        "relation_label": [
+          "is causal germline mutation in"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:7897",
+        "target_id": "MONDO:0019245",
+        "type": "contributes_to"
+      },
+      {
+        "ctime": [
+          1573156105.3854544
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "26597a2cf6d997bc4e88b80af19b69b2",
+        "predicate_id": "RO:0002410",
+        "publications": [
+          "PMID:16098014",
+          "PMID:22065762",
+          "PMID:19718781",
+          "PMID:26206375",
+          "PMID:27366019",
+          "PMID:15465421",
+          "PMID:27549128",
+          "PMID:25425405",
+          "PMID:27139891",
+          "PMID:20826119",
+          "PMID:29197565",
+          "PMID:11479732",
+          "PMID:21245028",
+          "PMID:11545687",
+          "PMID:24506780",
+          "PMID:4795418",
+          "PMID:20718790",
+          "PMID:11754101",
+          "PMID:26338816",
+          "PMID:20521171",
+          "PMID:29100954",
+          "PMID:17989072",
+          "PMID:18216017",
+          "PMID:22750297",
+          "PMID:25326637",
+          "PMID:10480349",
+          "PMID:9211849",
+          "PMID:23433426",
+          "PMID:26939636",
+          "PMID:27193329",
+          "PMID:9211850",
+          "PMID:25149939",
+          "PMID:16126423",
+          "PMID:12205649",
+          "PMID:9634529",
+          "PMID:25637190",
+          "PMID:11349231",
+          "PMID:23593294",
+          "PMID:23146215",
+          "PMID:16138904",
+          "PMID:22476655",
+          "PMID:12719428",
+          "PMID:26666848",
+          "PMID:23427322",
+          "PMID:16720792",
+          "PMID:10521297",
+          "PMID:19900398",
+          "PMID:23453666",
+          "PMID:28167839",
+          "PMID:24001525",
+          "PMID:19252935",
+          "PMID:24767253",
+          "PMID:12554680",
+          "PMID:10521290",
+          "PMID:17160617",
+          "PMID:27238017",
+          "PMID:19013089",
+          "PMID:26108224",
+          "PMID:11333381",
+          "PMID:27900365",
+          "PMID:25131710",
+          "PMID:28222799",
+          "PMID:24676439",
+          "PMID:23653225",
+          "PMID:28193631",
+          "PMID:23430855",
+          "PMID:11182931",
+          "PMID:12401890",
+          "PMID:26981555",
+          "PMID:15459971",
+          "PMID:19206179",
+          "PMID:15130691",
+          "PMID:27959697",
+          "PMID:15596783",
+          "PMID:23773996",
+          "PMID:19744920",
+          "PMID:19223215",
+          "PMID:23142039",
+          "PMID:24915861",
+          "PMID:22326530",
+          "PMID:25349751",
+          "PMID:22704015",
+          "PMID:24570279",
+          "PMID:9927649",
+          "PMID:25764212",
+          "PMID:24386122",
+          "PMID:27581084",
+          "PMID:26937389",
+          "PMID:17003072",
+          "PMID:25236789",
+          "PMID:12955717",
+          "PMID:27378690",
+          "PMID:26984608",
+          "PMID:27706244",
+          "PMID:19609713",
+          "PMID:3378364",
+          "PMID:28802248",
+          "PMID:26019327",
+          "PMID:15774455",
+          "PMID:12408188",
+          "PMID:23774949",
+          "PMID:22505584",
+          "PMID:28130309",
+          "PMID:12974729",
+          "PMID:22676771",
+          "PMID:28480683",
+          "PMID:28155026",
+          "PMID:19307542",
+          "PMID:16778374"
+        ],
+        "relation": [
+          "RO:0003303"
+        ],
+        "relation_label": [
+          "causes condition"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:7897",
+        "target_id": "MONDO:0019245",
+        "type": "causes"
+      },
+      {
+        "ctime": [
+          1573156169.8263385
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "29af30b5ed34429bc974c8f7c3837415",
+        "predicate_id": "RO:0002326",
+        "publications": [],
+        "relation": [
+          "RO:0004013"
+        ],
+        "relation_label": [
+          "is causal germline mutation in"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:7897",
+        "target_id": "MONDO:0019255",
+        "type": "contributes_to"
+      },
+      {
+        "ctime": [
+          1573156169.826728
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "e9d313a77d019672f0c96a8ef14ea0c0",
+        "predicate_id": "RO:0002410",
+        "publications": [
+          "PMID:16098014",
+          "PMID:22065762",
+          "PMID:19718781",
+          "PMID:26206375",
+          "PMID:27366019",
+          "PMID:15465421",
+          "PMID:27549128",
+          "PMID:25425405",
+          "PMID:27139891",
+          "PMID:20826119",
+          "PMID:29197565",
+          "PMID:11479732",
+          "PMID:21245028",
+          "PMID:11545687",
+          "PMID:24506780",
+          "PMID:4795418",
+          "PMID:20718790",
+          "PMID:11754101",
+          "PMID:26338816",
+          "PMID:20521171",
+          "PMID:29100954",
+          "PMID:17989072",
+          "PMID:18216017",
+          "PMID:22750297",
+          "PMID:25326637",
+          "PMID:10480349",
+          "PMID:9211849",
+          "PMID:23433426",
+          "PMID:26939636",
+          "PMID:27193329",
+          "PMID:9211850",
+          "PMID:25149939",
+          "PMID:16126423",
+          "PMID:12205649",
+          "PMID:9634529",
+          "PMID:25637190",
+          "PMID:11349231",
+          "PMID:23593294",
+          "PMID:23146215",
+          "PMID:16138904",
+          "PMID:22476655",
+          "PMID:12719428",
+          "PMID:26666848",
+          "PMID:23427322",
+          "PMID:16720792",
+          "PMID:10521297",
+          "PMID:19900398",
+          "PMID:23453666",
+          "PMID:28167839",
+          "PMID:24001525",
+          "PMID:19252935",
+          "PMID:24767253",
+          "PMID:12554680",
+          "PMID:10521290",
+          "PMID:17160617",
+          "PMID:27238017",
+          "PMID:19013089",
+          "PMID:26108224",
+          "PMID:11333381",
+          "PMID:27900365",
+          "PMID:25131710",
+          "PMID:28222799",
+          "PMID:24676439",
+          "PMID:23653225",
+          "PMID:28193631",
+          "PMID:23430855",
+          "PMID:11182931",
+          "PMID:12401890",
+          "PMID:26981555",
+          "PMID:15459971",
+          "PMID:19206179",
+          "PMID:15130691",
+          "PMID:27959697",
+          "PMID:15596783",
+          "PMID:23773996",
+          "PMID:19744920",
+          "PMID:19223215",
+          "PMID:23142039",
+          "PMID:24915861",
+          "PMID:22326530",
+          "PMID:25349751",
+          "PMID:22704015",
+          "PMID:24570279",
+          "PMID:9927649",
+          "PMID:25764212",
+          "PMID:24386122",
+          "PMID:27581084",
+          "PMID:26937389",
+          "PMID:17003072",
+          "PMID:25236789",
+          "PMID:12955717",
+          "PMID:27378690",
+          "PMID:26984608",
+          "PMID:27706244",
+          "PMID:19609713",
+          "PMID:3378364",
+          "PMID:28802248",
+          "PMID:26019327",
+          "PMID:15774455",
+          "PMID:12408188",
+          "PMID:23774949",
+          "PMID:22505584",
+          "PMID:28130309",
+          "PMID:12974729",
+          "PMID:22676771",
+          "PMID:28480683",
+          "PMID:28155026",
+          "PMID:19307542",
+          "PMID:16778374"
+        ],
+        "relation": [
+          "RO:0003303"
+        ],
+        "relation_label": [
+          "causes condition"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:7897",
+        "target_id": "MONDO:0019255",
+        "type": "causes"
+      },
+      {
+        "ctime": [
+          1573156592.0033767,
+          1572909411.898204
+        ],
+        "edge_source": [
+          "pharos.disease_get_gene",
+          "pharos.gene_get_disease"
+        ],
+        "id": "d5c5155df21271424395bf907352723b",
+        "predicate_id": "NCIT:R176",
+        "publications": [],
+        "relation": [
+          "PHAROS:gene_involved",
+          "PHAROS:gene_involved"
+        ],
+        "relation_label": [
+          "gene_involved",
+          "gene_involved"
+        ],
+        "source_database": [
+          "pharos",
+          "pharos"
+        ],
+        "source_id": "MONDO:0001982",
+        "target_id": "HGNC:7897",
+        "type": "disease_to_gene_association"
+      },
+      {
+        "ctime": [
+          1573156594.6198087
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "54def4d64ef4cdca73611e914dd551a7",
+        "predicate_id": "RO:0002326",
+        "publications": [],
+        "relation": [
+          "RO:0004013"
+        ],
+        "relation_label": [
+          "is causal germline mutation in"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:7897",
+        "target_id": "MONDO:0001982",
+        "type": "contributes_to"
+      },
+      {
+        "ctime": [
+          1573156594.6202688
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "9791fbb15863871831688aa2f9eda7af",
+        "predicate_id": "RO:0002410",
+        "publications": [
+          "PMID:16098014",
+          "PMID:22065762",
+          "PMID:19718781",
+          "PMID:26206375",
+          "PMID:27366019",
+          "PMID:15465421",
+          "PMID:27549128",
+          "PMID:25425405",
+          "PMID:27139891",
+          "PMID:20826119",
+          "PMID:29197565",
+          "PMID:11479732",
+          "PMID:21245028",
+          "PMID:11545687",
+          "PMID:24506780",
+          "PMID:4795418",
+          "PMID:20718790",
+          "PMID:11754101",
+          "PMID:26338816",
+          "PMID:20521171",
+          "PMID:29100954",
+          "PMID:17989072",
+          "PMID:18216017",
+          "PMID:22750297",
+          "PMID:25326637",
+          "PMID:10480349",
+          "PMID:9211849",
+          "PMID:23433426",
+          "PMID:26939636",
+          "PMID:27193329",
+          "PMID:9211850",
+          "PMID:25149939",
+          "PMID:16126423",
+          "PMID:12205649",
+          "PMID:9634529",
+          "PMID:25637190",
+          "PMID:11349231",
+          "PMID:23593294",
+          "PMID:23146215",
+          "PMID:16138904",
+          "PMID:22476655",
+          "PMID:12719428",
+          "PMID:26666848",
+          "PMID:23427322",
+          "PMID:16720792",
+          "PMID:10521297",
+          "PMID:19900398",
+          "PMID:23453666",
+          "PMID:28167839",
+          "PMID:24001525",
+          "PMID:19252935",
+          "PMID:24767253",
+          "PMID:12554680",
+          "PMID:10521290",
+          "PMID:17160617",
+          "PMID:27238017",
+          "PMID:19013089",
+          "PMID:26108224",
+          "PMID:11333381",
+          "PMID:27900365",
+          "PMID:25131710",
+          "PMID:28222799",
+          "PMID:24676439",
+          "PMID:23653225",
+          "PMID:28193631",
+          "PMID:23430855",
+          "PMID:11182931",
+          "PMID:12401890",
+          "PMID:26981555",
+          "PMID:15459971",
+          "PMID:19206179",
+          "PMID:15130691",
+          "PMID:27959697",
+          "PMID:15596783",
+          "PMID:23773996",
+          "PMID:19744920",
+          "PMID:19223215",
+          "PMID:23142039",
+          "PMID:24915861",
+          "PMID:22326530",
+          "PMID:25349751",
+          "PMID:22704015",
+          "PMID:24570279",
+          "PMID:9927649",
+          "PMID:25764212",
+          "PMID:24386122",
+          "PMID:27581084",
+          "PMID:26937389",
+          "PMID:17003072",
+          "PMID:25236789",
+          "PMID:12955717",
+          "PMID:27378690",
+          "PMID:26984608",
+          "PMID:27706244",
+          "PMID:19609713",
+          "PMID:3378364",
+          "PMID:28802248",
+          "PMID:26019327",
+          "PMID:15774455",
+          "PMID:12408188",
+          "PMID:23774949",
+          "PMID:22505584",
+          "PMID:28130309",
+          "PMID:12974729",
+          "PMID:22676771",
+          "PMID:28480683",
+          "PMID:28155026",
+          "PMID:19307542",
+          "PMID:16778374"
+        ],
+        "relation": [
+          "RO:0003303"
+        ],
+        "relation_label": [
+          "causes condition"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:7897",
+        "target_id": "MONDO:0001982",
+        "type": "causes"
+      },
+      {
+        "ctime": [
+          1573156768.1828094,
+          1572923055.3117104
+        ],
+        "edge_source": [
+          "pharos.disease_get_gene",
+          "pharos.gene_get_disease"
+        ],
+        "id": "ecc41c5a4a6d0ae6632ca4456ec754b8",
+        "predicate_id": "NCIT:R176",
+        "publications": [],
+        "relation": [
+          "PHAROS:gene_involved",
+          "PHAROS:gene_involved"
+        ],
+        "relation_label": [
+          "gene_involved",
+          "gene_involved"
+        ],
+        "source_database": [
+          "pharos",
+          "pharos"
+        ],
+        "source_id": "MONDO:0013674",
+        "target_id": "HGNC:13236",
+        "type": "disease_to_gene_association"
+      },
+      {
+        "ctime": [
+          1573156977.2334924
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "0639d713dc11b8f59ee56bb3c8b663a0",
+        "predicate_id": "RO:0002326",
+        "publications": [],
+        "relation": [
+          "RO:0004013"
+        ],
+        "relation_label": [
+          "is causal germline mutation in"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:7897",
+        "target_id": "MONDO:0019052",
+        "type": "contributes_to"
+      },
+      {
+        "ctime": [
+          1573156977.2338624
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "8e8ee0341df31126c1ed224a904c90e3",
+        "predicate_id": "RO:0002410",
+        "publications": [
+          "PMID:16098014",
+          "PMID:22065762",
+          "PMID:19718781",
+          "PMID:26206375",
+          "PMID:27366019",
+          "PMID:15465421",
+          "PMID:27549128",
+          "PMID:25425405",
+          "PMID:27139891",
+          "PMID:20826119",
+          "PMID:29197565",
+          "PMID:11479732",
+          "PMID:21245028",
+          "PMID:11545687",
+          "PMID:24506780",
+          "PMID:4795418",
+          "PMID:20718790",
+          "PMID:11754101",
+          "PMID:26338816",
+          "PMID:20521171",
+          "PMID:29100954",
+          "PMID:17989072",
+          "PMID:18216017",
+          "PMID:22750297",
+          "PMID:25326637",
+          "PMID:10480349",
+          "PMID:9211849",
+          "PMID:23433426",
+          "PMID:26939636",
+          "PMID:27193329",
+          "PMID:9211850",
+          "PMID:25149939",
+          "PMID:16126423",
+          "PMID:12205649",
+          "PMID:9634529",
+          "PMID:25637190",
+          "PMID:11349231",
+          "PMID:23593294",
+          "PMID:23146215",
+          "PMID:16138904",
+          "PMID:22476655",
+          "PMID:12719428",
+          "PMID:26666848",
+          "PMID:23427322",
+          "PMID:16720792",
+          "PMID:10521297",
+          "PMID:19900398",
+          "PMID:23453666",
+          "PMID:28167839",
+          "PMID:24001525",
+          "PMID:19252935",
+          "PMID:24767253",
+          "PMID:12554680",
+          "PMID:10521290",
+          "PMID:17160617",
+          "PMID:27238017",
+          "PMID:19013089",
+          "PMID:26108224",
+          "PMID:11333381",
+          "PMID:27900365",
+          "PMID:25131710",
+          "PMID:28222799",
+          "PMID:24676439",
+          "PMID:23653225",
+          "PMID:28193631",
+          "PMID:23430855",
+          "PMID:11182931",
+          "PMID:12401890",
+          "PMID:26981555",
+          "PMID:15459971",
+          "PMID:19206179",
+          "PMID:15130691",
+          "PMID:27959697",
+          "PMID:15596783",
+          "PMID:23773996",
+          "PMID:19744920",
+          "PMID:19223215",
+          "PMID:23142039",
+          "PMID:24915861",
+          "PMID:22326530",
+          "PMID:25349751",
+          "PMID:22704015",
+          "PMID:24570279",
+          "PMID:9927649",
+          "PMID:25764212",
+          "PMID:24386122",
+          "PMID:27581084",
+          "PMID:26937389",
+          "PMID:17003072",
+          "PMID:25236789",
+          "PMID:12955717",
+          "PMID:27378690",
+          "PMID:26984608",
+          "PMID:27706244",
+          "PMID:19609713",
+          "PMID:3378364",
+          "PMID:28802248",
+          "PMID:26019327",
+          "PMID:15774455",
+          "PMID:12408188",
+          "PMID:23774949",
+          "PMID:22505584",
+          "PMID:28130309",
+          "PMID:12974729",
+          "PMID:22676771",
+          "PMID:28480683",
+          "PMID:28155026",
+          "PMID:19307542",
+          "PMID:16778374"
+        ],
+        "relation": [
+          "RO:0003303"
+        ],
+        "relation_label": [
+          "causes condition"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:7897",
+        "target_id": "MONDO:0019052",
+        "type": "causes"
+      },
+      {
+        "ctime": [
+          1573156866.0994604
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "cf371e56214fa6a66db2c1c39fa3ff55",
+        "predicate_id": "RO:0002410",
+        "publications": [
+          "PMID:21937992",
+          "PMID:23773660"
+        ],
+        "relation": [
+          "RO:0003303"
+        ],
+        "relation_label": [
+          "causes condition"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:30922",
+        "target_id": "MONDO:0013702",
+        "type": "causes"
+      },
+      {
+        "ctime": [
+          1573157420.8886578
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "66a851fea2dfd6eec9223b5cfcdecf3c",
+        "predicate_id": "RO:0002326",
+        "publications": [],
+        "relation": [
+          "RO:0003304"
+        ],
+        "relation_label": [
+          "contributes to condition"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:16361",
+        "target_id": "MONDO:0019118",
+        "type": "contributes_to"
+      },
+      {
+        "ctime": [
+          1573157420.9212344
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "9b892ba625b82b91b42ac79c42df5287",
+        "predicate_id": "RO:0002326",
+        "publications": [],
+        "relation": [
+          "RO:0004013"
+        ],
+        "relation_label": [
+          "is causal germline mutation in"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:7897",
+        "target_id": "MONDO:0019118",
+        "type": "contributes_to"
+      },
+      {
+        "ctime": [
+          1573157420.921624
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "22b290072185ddefea142bb8190aea54",
+        "predicate_id": "RO:0002410",
+        "publications": [
+          "PMID:16098014",
+          "PMID:22065762",
+          "PMID:19718781",
+          "PMID:26206375",
+          "PMID:27366019",
+          "PMID:15465421",
+          "PMID:27549128",
+          "PMID:25425405",
+          "PMID:27139891",
+          "PMID:20826119",
+          "PMID:29197565",
+          "PMID:11479732",
+          "PMID:21245028",
+          "PMID:11545687",
+          "PMID:24506780",
+          "PMID:4795418",
+          "PMID:20718790",
+          "PMID:11754101",
+          "PMID:26338816",
+          "PMID:20521171",
+          "PMID:29100954",
+          "PMID:17989072",
+          "PMID:18216017",
+          "PMID:22750297",
+          "PMID:25326637",
+          "PMID:10480349",
+          "PMID:9211849",
+          "PMID:23433426",
+          "PMID:26939636",
+          "PMID:27193329",
+          "PMID:9211850",
+          "PMID:25149939",
+          "PMID:16126423",
+          "PMID:12205649",
+          "PMID:9634529",
+          "PMID:25637190",
+          "PMID:11349231",
+          "PMID:23593294",
+          "PMID:23146215",
+          "PMID:16138904",
+          "PMID:22476655",
+          "PMID:12719428",
+          "PMID:26666848",
+          "PMID:23427322",
+          "PMID:16720792",
+          "PMID:10521297",
+          "PMID:19900398",
+          "PMID:23453666",
+          "PMID:28167839",
+          "PMID:24001525",
+          "PMID:19252935",
+          "PMID:24767253",
+          "PMID:12554680",
+          "PMID:10521290",
+          "PMID:17160617",
+          "PMID:27238017",
+          "PMID:19013089",
+          "PMID:26108224",
+          "PMID:11333381",
+          "PMID:27900365",
+          "PMID:25131710",
+          "PMID:28222799",
+          "PMID:24676439",
+          "PMID:23653225",
+          "PMID:28193631",
+          "PMID:23430855",
+          "PMID:11182931",
+          "PMID:12401890",
+          "PMID:26981555",
+          "PMID:15459971",
+          "PMID:19206179",
+          "PMID:15130691",
+          "PMID:27959697",
+          "PMID:15596783",
+          "PMID:23773996",
+          "PMID:19744920",
+          "PMID:19223215",
+          "PMID:23142039",
+          "PMID:24915861",
+          "PMID:22326530",
+          "PMID:25349751",
+          "PMID:22704015",
+          "PMID:24570279",
+          "PMID:9927649",
+          "PMID:25764212",
+          "PMID:24386122",
+          "PMID:27581084",
+          "PMID:26937389",
+          "PMID:17003072",
+          "PMID:25236789",
+          "PMID:12955717",
+          "PMID:27378690",
+          "PMID:26984608",
+          "PMID:27706244",
+          "PMID:19609713",
+          "PMID:3378364",
+          "PMID:28802248",
+          "PMID:26019327",
+          "PMID:15774455",
+          "PMID:12408188",
+          "PMID:23774949",
+          "PMID:22505584",
+          "PMID:28130309",
+          "PMID:12974729",
+          "PMID:22676771",
+          "PMID:28480683",
+          "PMID:28155026",
+          "PMID:19307542",
+          "PMID:16778374"
+        ],
+        "relation": [
+          "RO:0003303"
+        ],
+        "relation_label": [
+          "causes condition"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:7897",
+        "target_id": "MONDO:0019118",
+        "type": "causes"
+      },
+      {
+        "ctime": [
+          1573157420.9260037
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "67669afd50f8b405a96cdf6bbd322927",
+        "predicate_id": "RO:0002410",
+        "publications": [
+          "PMID:17171570"
+        ],
+        "relation": [
+          "RO:0003303"
+        ],
+        "relation_label": [
+          "causes condition"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:16361",
+        "target_id": "MONDO:0019118",
+        "type": "causes"
+      },
+      {
+        "ctime": [
+          1573157077.4087663
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "b4451ab465d13e44c19c4e5703befc90",
+        "predicate_id": "RO:0002410",
+        "publications": [
+          "PMID:16098014",
+          "PMID:22065762",
+          "PMID:19718781",
+          "PMID:26206375",
+          "PMID:27366019",
+          "PMID:15465421",
+          "PMID:27549128",
+          "PMID:25425405",
+          "PMID:27139891",
+          "PMID:20826119",
+          "PMID:29197565",
+          "PMID:11479732",
+          "PMID:21245028",
+          "PMID:11545687",
+          "PMID:24506780",
+          "PMID:4795418",
+          "PMID:20718790",
+          "PMID:11754101",
+          "PMID:26338816",
+          "PMID:20521171",
+          "PMID:29100954",
+          "PMID:17989072",
+          "PMID:18216017",
+          "PMID:22750297",
+          "PMID:25326637",
+          "PMID:10480349",
+          "PMID:9211849",
+          "PMID:23433426",
+          "PMID:26939636",
+          "PMID:27193329",
+          "PMID:9211850",
+          "PMID:25149939",
+          "PMID:16126423",
+          "PMID:12205649",
+          "PMID:9634529",
+          "PMID:25637190",
+          "PMID:11349231",
+          "PMID:23593294",
+          "PMID:23146215",
+          "PMID:16138904",
+          "PMID:22476655",
+          "PMID:12719428",
+          "PMID:26666848",
+          "PMID:23427322",
+          "PMID:16720792",
+          "PMID:10521297",
+          "PMID:19900398",
+          "PMID:23453666",
+          "PMID:28167839",
+          "PMID:24001525",
+          "PMID:19252935",
+          "PMID:24767253",
+          "PMID:12554680",
+          "PMID:10521290",
+          "PMID:17160617",
+          "PMID:27238017",
+          "PMID:19013089",
+          "PMID:26108224",
+          "PMID:11333381",
+          "PMID:27900365",
+          "PMID:25131710",
+          "PMID:28222799",
+          "PMID:24676439",
+          "PMID:23653225",
+          "PMID:28193631",
+          "PMID:23430855",
+          "PMID:11182931",
+          "PMID:12401890",
+          "PMID:26981555",
+          "PMID:15459971",
+          "PMID:19206179",
+          "PMID:15130691",
+          "PMID:27959697",
+          "PMID:15596783",
+          "PMID:23773996",
+          "PMID:19744920",
+          "PMID:19223215",
+          "PMID:23142039",
+          "PMID:24915861",
+          "PMID:22326530",
+          "PMID:25349751",
+          "PMID:22704015",
+          "PMID:24570279",
+          "PMID:9927649",
+          "PMID:25764212",
+          "PMID:24386122",
+          "PMID:27581084",
+          "PMID:26937389",
+          "PMID:17003072",
+          "PMID:25236789",
+          "PMID:12955717",
+          "PMID:27378690",
+          "PMID:26984608",
+          "PMID:27706244",
+          "PMID:19609713",
+          "PMID:3378364",
+          "PMID:28802248",
+          "PMID:26019327",
+          "PMID:15774455",
+          "PMID:12408188",
+          "PMID:23774949",
+          "PMID:22505584",
+          "PMID:28130309",
+          "PMID:12974729",
+          "PMID:22676771",
+          "PMID:28480683",
+          "PMID:28155026",
+          "PMID:19307542",
+          "PMID:16778374"
+        ],
+        "relation": [
+          "RO:0003303"
+        ],
+        "relation_label": [
+          "causes condition"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:7897",
+        "target_id": "MONDO:0019058",
+        "type": "causes"
+      },
+      {
+        "ctime": [
+          1573157077.4083421
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "3726c1decb208d06bdffe464a68b940e",
+        "predicate_id": "RO:0002326",
+        "publications": [],
+        "relation": [
+          "RO:0004013"
+        ],
+        "relation_label": [
+          "is causal germline mutation in"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:7897",
+        "target_id": "MONDO:0019058",
+        "type": "contributes_to"
+      },
+      {
+        "ctime": [
+          1573157655.0049698,
+          1572931707.7468615
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene",
+          "biolink.gene_get_disease"
+        ],
+        "id": "109f0ce42854fcfd971c53fe565d98b3",
+        "predicate_id": "RO:0002410",
+        "publications": [
+          "PMID:15841483",
+          "PMID:12833159",
+          "PMID:11973626"
+        ],
+        "relation": [
+          "RO:0003303",
+          "RO:0003303"
+        ],
+        "relation_label": [
+          "causes condition",
+          "causes condition"
+        ],
+        "source_database": [
+          "biolink",
+          "biolink"
+        ],
+        "source_id": "HGNC:16361",
+        "target_id": "MONDO:0011767",
+        "type": "causes"
+      },
+      {
+        "ctime": [
+          1573157697.9590886
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "de338f46d2c865c1306a3d3af4b4d5f3",
+        "predicate_id": "RO:0002326",
+        "publications": [],
+        "relation": [
+          "RO:0003304"
+        ],
+        "relation_label": [
+          "contributes to condition"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:16361",
+        "target_id": "MONDO:0019200",
+        "type": "contributes_to"
+      },
+      {
+        "ctime": [
+          1573157697.9754648
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "1872bc68cf27fe5275d4f05f41a0fff3",
+        "predicate_id": "RO:0002410",
+        "publications": [
+          "PMID:17171570"
+        ],
+        "relation": [
+          "RO:0003303"
+        ],
+        "relation_label": [
+          "causes condition"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:16361",
+        "target_id": "MONDO:0019200",
+        "type": "causes"
+      },
+      {
+        "ctime": [
+          1573157681.0543463,
+          1572931709.11714
+        ],
+        "edge_source": [
+          "pharos.disease_get_gene",
+          "pharos.gene_get_disease"
+        ],
+        "id": "d7eaeec59c7fcf27c8ea336e191601a2",
+        "predicate_id": "NCIT:R176",
+        "publications": [],
+        "relation": [
+          "PHAROS:gene_involved",
+          "PHAROS:gene_involved"
+        ],
+        "relation_label": [
+          "gene_involved",
+          "gene_involved"
+        ],
+        "source_database": [
+          "pharos",
+          "pharos"
+        ],
+        "source_id": "MONDO:0019200",
+        "target_id": "HGNC:16361",
+        "type": "disease_to_gene_association"
+      },
+      {
+        "ctime": [
+          1573158540.5339403,
+          1572931707.746939
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene",
+          "biolink.gene_get_disease"
+        ],
+        "id": "14d7e27b4775285337956da529a1e374",
+        "predicate_id": "RO:0002410",
+        "publications": [
+          "PMID:17171570"
+        ],
+        "relation": [
+          "RO:0003303",
+          "RO:0003303"
+        ],
+        "relation_label": [
+          "causes condition",
+          "causes condition"
+        ],
+        "source_database": [
+          "biolink",
+          "biolink"
+        ],
+        "source_id": "HGNC:16361",
+        "target_id": "MONDO:0012662",
+        "type": "causes"
+      },
+      {
+        "ctime": [
+          1573159191.5917718
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "e2f7ba2993d6b4d05ea2a97acb305a9a",
+        "predicate_id": "RO:0002410",
+        "publications": [
+          "PMID:15841483",
+          "PMID:12833159",
+          "PMID:11973626"
+        ],
+        "relation": [
+          "RO:0003303"
+        ],
+        "relation_label": [
+          "causes condition"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:16361",
+        "target_id": "MONDO:0016297",
+        "type": "causes"
+      },
+      {
+        "ctime": [
+          1573159191.5917192
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "90fa46e46242ea7431159dcbb2d052a7",
+        "predicate_id": "RO:0002326",
+        "publications": [],
+        "relation": [
+          "RO:0004013"
+        ],
+        "relation_label": [
+          "is causal germline mutation in"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:16361",
+        "target_id": "MONDO:0016297",
+        "type": "contributes_to"
+      },
+      {
+        "ctime": [
+          1573159205.622433
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "a88d6179a1575003c2d5d7a1ed912c37",
+        "predicate_id": "RO:0002410",
+        "publications": [
+          "PMID:15841483",
+          "PMID:12833159",
+          "PMID:11973626"
+        ],
+        "relation": [
+          "RO:0003303"
+        ],
+        "relation_label": [
+          "causes condition"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:16361",
+        "target_id": "MONDO:0016298",
+        "type": "causes"
+      },
+      {
+        "ctime": [
+          1573159205.6223884
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "d98ec3a027618459ebb27d5cc5ec708d",
+        "predicate_id": "RO:0002326",
+        "publications": [],
+        "relation": [
+          "RO:0004013"
+        ],
+        "relation_label": [
+          "is causal germline mutation in"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:16361",
+        "target_id": "MONDO:0016298",
+        "type": "contributes_to"
+      },
+      {
+        "ctime": [
+          1573159226.1799664,
+          1572909410.3878756
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene",
+          "biolink.gene_get_disease"
+        ],
+        "id": "6e61c85fbf28cadd5365c88fc8fb0332",
+        "predicate_id": "RO:0002326",
+        "publications": [],
+        "relation": [
+          "RO:0004013",
+          "RO:0004013"
+        ],
+        "relation_label": [
+          "is causal germline mutation in",
+          "is causal germline mutation in"
+        ],
+        "source_database": [
+          "biolink",
+          "biolink"
+        ],
+        "source_id": "HGNC:7897",
+        "target_id": "MONDO:0016306",
+        "type": "contributes_to"
+      },
+      {
+        "ctime": [
+          1573159230.3344562,
+          1572909410.3879728
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene",
+          "biolink.gene_get_disease"
+        ],
+        "id": "4148488aa46bed29a30e746065e84316",
+        "predicate_id": "RO:0002326",
+        "publications": [],
+        "relation": [
+          "RO:0004013",
+          "RO:0004013"
+        ],
+        "relation_label": [
+          "is causal germline mutation in",
+          "is causal germline mutation in"
+        ],
+        "source_database": [
+          "biolink",
+          "biolink"
+        ],
+        "source_id": "HGNC:7897",
+        "target_id": "MONDO:0016307",
+        "type": "contributes_to"
+      },
+      {
+        "ctime": [
+          1573159235.7113242,
+          1572909410.388052
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene",
+          "biolink.gene_get_disease"
+        ],
+        "id": "92dec38d8ddffb1ec3957f6fb6e363c6",
+        "predicate_id": "RO:0002326",
+        "publications": [],
+        "relation": [
+          "RO:0004013",
+          "RO:0004013"
+        ],
+        "relation_label": [
+          "is causal germline mutation in",
+          "is causal germline mutation in"
+        ],
+        "source_database": [
+          "biolink",
+          "biolink"
+        ],
+        "source_id": "HGNC:7897",
+        "target_id": "MONDO:0016308",
+        "type": "contributes_to"
+      },
+      {
+        "ctime": [
+          1573159239.4613755,
+          1572909410.388216
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene",
+          "biolink.gene_get_disease"
+        ],
+        "id": "0f844cbbd9e0f8ef23203e568c035c8e",
+        "predicate_id": "RO:0002326",
+        "publications": [],
+        "relation": [
+          "RO:0004013",
+          "RO:0004013"
+        ],
+        "relation_label": [
+          "is causal germline mutation in",
+          "is causal germline mutation in"
+        ],
+        "source_database": [
+          "biolink",
+          "biolink"
+        ],
+        "source_id": "HGNC:7897",
+        "target_id": "MONDO:0016309",
+        "type": "contributes_to"
+      },
+      {
+        "ctime": [
+          1573159243.2382703,
+          1572909410.3881361
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene",
+          "biolink.gene_get_disease"
+        ],
+        "id": "e7bf683f8eec9a78876980b936c0e8bd",
+        "predicate_id": "RO:0002326",
+        "publications": [],
+        "relation": [
+          "RO:0004013",
+          "RO:0004013"
+        ],
+        "relation_label": [
+          "is causal germline mutation in",
+          "is causal germline mutation in"
+        ],
+        "source_database": [
+          "biolink",
+          "biolink"
+        ],
+        "source_id": "HGNC:7897",
+        "target_id": "MONDO:0016310",
+        "type": "contributes_to"
+      },
+      {
+        "ctime": [
+          1573159376.0305226,
+          1572919447.3172987
+        ],
+        "edge_source": [
+          "pharos.disease_get_gene",
+          "pharos.gene_get_disease"
+        ],
+        "id": "bc8cec26ab2c2ce305bf66a8792f4fd2",
+        "predicate_id": "NCIT:R176",
+        "publications": [],
+        "relation": [
+          "PHAROS:gene_involved",
+          "PHAROS:gene_involved"
+        ],
+        "relation_label": [
+          "gene_involved",
+          "gene_involved"
+        ],
+        "source_database": [
+          "pharos",
+          "pharos"
+        ],
+        "source_id": "MONDO:0019262",
+        "target_id": "HGNC:20818",
+        "type": "disease_to_gene_association"
+      },
+      {
+        "ctime": [
+          1573159407.514817
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "7d508dca4af620c13ddb24bc5cee7de9",
+        "predicate_id": "RO:0002326",
+        "publications": [],
+        "relation": [
+          "RO:0003304"
+        ],
+        "relation_label": [
+          "contributes to condition"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:16361",
+        "target_id": "MONDO:0006025",
+        "type": "contributes_to"
+      },
+      {
+        "ctime": [
+          1573159407.5167236
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "2c1175ce9d7c5b3983550dd87f11b45a",
+        "predicate_id": "RO:0002326",
+        "publications": [],
+        "relation": [
+          "RO:0004013"
+        ],
+        "relation_label": [
+          "is causal germline mutation in"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:30922",
+        "target_id": "MONDO:0006025",
+        "type": "contributes_to"
+      },
+      {
+        "ctime": [
+          1573159407.5168333
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "f9997d4cf53426d4633dfe18e78bd33e",
+        "predicate_id": "RO:0002410",
+        "publications": [
+          "PMID:21937992",
+          "PMID:23773660"
+        ],
+        "relation": [
+          "RO:0003303"
+        ],
+        "relation_label": [
+          "causes condition"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:30922",
+        "target_id": "MONDO:0006025",
+        "type": "causes"
+      },
+      {
+        "ctime": [
+          1573159407.5800738
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "dfe342b3ca8a213b5684608610bf4311",
+        "predicate_id": "RO:0002326",
+        "publications": [],
+        "relation": [
+          "RO:0004013"
+        ],
+        "relation_label": [
+          "is causal germline mutation in"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:7897",
+        "target_id": "MONDO:0006025",
+        "type": "contributes_to"
+      },
+      {
+        "ctime": [
+          1573159407.5804627
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "57484a4caa299dd55a20f7cd072e18f4",
+        "predicate_id": "RO:0002410",
+        "publications": [
+          "PMID:16098014",
+          "PMID:22065762",
+          "PMID:19718781",
+          "PMID:26206375",
+          "PMID:27366019",
+          "PMID:15465421",
+          "PMID:27549128",
+          "PMID:25425405",
+          "PMID:27139891",
+          "PMID:20826119",
+          "PMID:29197565",
+          "PMID:11479732",
+          "PMID:21245028",
+          "PMID:11545687",
+          "PMID:24506780",
+          "PMID:4795418",
+          "PMID:20718790",
+          "PMID:11754101",
+          "PMID:26338816",
+          "PMID:20521171",
+          "PMID:29100954",
+          "PMID:17989072",
+          "PMID:18216017",
+          "PMID:22750297",
+          "PMID:25326637",
+          "PMID:10480349",
+          "PMID:9211849",
+          "PMID:23433426",
+          "PMID:26939636",
+          "PMID:27193329",
+          "PMID:9211850",
+          "PMID:25149939",
+          "PMID:16126423",
+          "PMID:12205649",
+          "PMID:9634529",
+          "PMID:25637190",
+          "PMID:11349231",
+          "PMID:23593294",
+          "PMID:23146215",
+          "PMID:16138904",
+          "PMID:22476655",
+          "PMID:12719428",
+          "PMID:26666848",
+          "PMID:23427322",
+          "PMID:16720792",
+          "PMID:10521297",
+          "PMID:19900398",
+          "PMID:23453666",
+          "PMID:28167839",
+          "PMID:24001525",
+          "PMID:19252935",
+          "PMID:24767253",
+          "PMID:12554680",
+          "PMID:10521290",
+          "PMID:17160617",
+          "PMID:27238017",
+          "PMID:19013089",
+          "PMID:26108224",
+          "PMID:11333381",
+          "PMID:27900365",
+          "PMID:25131710",
+          "PMID:28222799",
+          "PMID:24676439",
+          "PMID:23653225",
+          "PMID:28193631",
+          "PMID:23430855",
+          "PMID:11182931",
+          "PMID:12401890",
+          "PMID:26981555",
+          "PMID:15459971",
+          "PMID:19206179",
+          "PMID:15130691",
+          "PMID:27959697",
+          "PMID:15596783",
+          "PMID:23773996",
+          "PMID:19744920",
+          "PMID:19223215",
+          "PMID:23142039",
+          "PMID:24915861",
+          "PMID:22326530",
+          "PMID:25349751",
+          "PMID:22704015",
+          "PMID:24570279",
+          "PMID:9927649",
+          "PMID:25764212",
+          "PMID:24386122",
+          "PMID:27581084",
+          "PMID:26937389",
+          "PMID:17003072",
+          "PMID:25236789",
+          "PMID:12955717",
+          "PMID:27378690",
+          "PMID:26984608",
+          "PMID:27706244",
+          "PMID:19609713",
+          "PMID:3378364",
+          "PMID:28802248",
+          "PMID:26019327",
+          "PMID:15774455",
+          "PMID:12408188",
+          "PMID:23774949",
+          "PMID:22505584",
+          "PMID:28130309",
+          "PMID:12974729",
+          "PMID:22676771",
+          "PMID:28480683",
+          "PMID:28155026",
+          "PMID:19307542",
+          "PMID:16778374"
+        ],
+        "relation": [
+          "RO:0003303"
+        ],
+        "relation_label": [
+          "causes condition"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:7897",
+        "target_id": "MONDO:0006025",
+        "type": "causes"
+      },
+      {
+        "ctime": [
+          1573159407.585776
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "fbc007ea2597f9423d5fcd000aef0bc6",
+        "predicate_id": "RO:0002410",
+        "publications": [
+          "PMID:15841483",
+          "PMID:12833159",
+          "PMID:11973626"
+        ],
+        "relation": [
+          "RO:0003303"
+        ],
+        "relation_label": [
+          "causes condition"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:16361",
+        "target_id": "MONDO:0006025",
+        "type": "causes"
+      },
+      {
+        "ctime": [
+          1573160054.3121574
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "dcc60e942d1f17e26d73dc5b73016462",
+        "predicate_id": "RO:0002410",
+        "publications": [
+          "PMID:16098014",
+          "PMID:22065762",
+          "PMID:19718781",
+          "PMID:26206375",
+          "PMID:27366019",
+          "PMID:15465421",
+          "PMID:27549128",
+          "PMID:25425405",
+          "PMID:27139891",
+          "PMID:20826119",
+          "PMID:29197565",
+          "PMID:11479732",
+          "PMID:21245028",
+          "PMID:11545687",
+          "PMID:24506780",
+          "PMID:4795418",
+          "PMID:20718790",
+          "PMID:11754101",
+          "PMID:26338816",
+          "PMID:20521171",
+          "PMID:29100954",
+          "PMID:17989072",
+          "PMID:18216017",
+          "PMID:22750297",
+          "PMID:25326637",
+          "PMID:10480349",
+          "PMID:9211849",
+          "PMID:23433426",
+          "PMID:26939636",
+          "PMID:27193329",
+          "PMID:9211850",
+          "PMID:25149939",
+          "PMID:16126423",
+          "PMID:12205649",
+          "PMID:9634529",
+          "PMID:25637190",
+          "PMID:11349231",
+          "PMID:23593294",
+          "PMID:23146215",
+          "PMID:16138904",
+          "PMID:22476655",
+          "PMID:12719428",
+          "PMID:26666848",
+          "PMID:23427322",
+          "PMID:16720792",
+          "PMID:10521297",
+          "PMID:19900398",
+          "PMID:23453666",
+          "PMID:28167839",
+          "PMID:24001525",
+          "PMID:19252935",
+          "PMID:24767253",
+          "PMID:12554680",
+          "PMID:10521290",
+          "PMID:17160617",
+          "PMID:27238017",
+          "PMID:19013089",
+          "PMID:26108224",
+          "PMID:11333381",
+          "PMID:27900365",
+          "PMID:25131710",
+          "PMID:28222799",
+          "PMID:24676439",
+          "PMID:23653225",
+          "PMID:28193631",
+          "PMID:23430855",
+          "PMID:11182931",
+          "PMID:12401890",
+          "PMID:26981555",
+          "PMID:15459971",
+          "PMID:19206179",
+          "PMID:15130691",
+          "PMID:27959697",
+          "PMID:15596783",
+          "PMID:23773996",
+          "PMID:19744920",
+          "PMID:19223215",
+          "PMID:23142039",
+          "PMID:24915861",
+          "PMID:22326530",
+          "PMID:25349751",
+          "PMID:22704015",
+          "PMID:24570279",
+          "PMID:9927649",
+          "PMID:25764212",
+          "PMID:24386122",
+          "PMID:27581084",
+          "PMID:26937389",
+          "PMID:17003072",
+          "PMID:25236789",
+          "PMID:12955717",
+          "PMID:27378690",
+          "PMID:26984608",
+          "PMID:27706244",
+          "PMID:19609713",
+          "PMID:3378364",
+          "PMID:28802248",
+          "PMID:26019327",
+          "PMID:15774455",
+          "PMID:12408188",
+          "PMID:23774949",
+          "PMID:22505584",
+          "PMID:28130309",
+          "PMID:12974729",
+          "PMID:22676771",
+          "PMID:28480683",
+          "PMID:28155026",
+          "PMID:19307542",
+          "PMID:16778374"
+        ],
+        "relation": [
+          "RO:0003303"
+        ],
+        "relation_label": [
+          "causes condition"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:7897",
+        "target_id": "MONDO:0018982",
+        "type": "causes"
+      },
+      {
+        "ctime": [
+          1573160054.3117425
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "80ac7bb75f91890fa90cbcdd94bd861d",
+        "predicate_id": "RO:0002326",
+        "publications": [],
+        "relation": [
+          "RO:0004013"
+        ],
+        "relation_label": [
+          "is causal germline mutation in"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:7897",
+        "target_id": "MONDO:0018982",
+        "type": "contributes_to"
+      },
+      {
+        "ctime": [
+          1573160533.6770813,
+          1572931709.1170812
+        ],
+        "edge_source": [
+          "pharos.disease_get_gene",
+          "pharos.gene_get_disease"
+        ],
+        "id": "860b7fd48e49ccb48fad4d3c9f98c66e",
+        "predicate_id": "NCIT:R176",
+        "publications": [],
+        "relation": [
+          "PHAROS:gene_involved",
+          "PHAROS:gene_involved"
+        ],
+        "relation_label": [
+          "gene_involved",
+          "gene_involved"
+        ],
+        "source_database": [
+          "pharos",
+          "pharos"
+        ],
+        "source_id": "MONDO:0019497",
+        "target_id": "HGNC:16361",
+        "type": "disease_to_gene_association"
+      },
+      {
+        "ctime": [
+          1573160545.605044,
+          1572916740.9730504
+        ],
+        "edge_source": [
+          "pharos.disease_get_gene",
+          "pharos.gene_get_disease"
+        ],
+        "id": "a5e000c14c184c57b21c832efcede470",
+        "predicate_id": "NCIT:R176",
+        "publications": [],
+        "relation": [
+          "PHAROS:gene_involved",
+          "PHAROS:gene_involved"
+        ],
+        "relation_label": [
+          "gene_involved",
+          "gene_involved"
+        ],
+        "source_database": [
+          "pharos",
+          "pharos"
+        ],
+        "source_id": "MONDO:0019502",
+        "target_id": "HGNC:30922",
+        "type": "disease_to_gene_association"
+      },
+      {
+        "ctime": [
+          1573160645.147327,
+          1572931707.7468176
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene",
+          "biolink.gene_get_disease"
+        ],
+        "id": "f0e5841a8dd1d1813ce6859cb0a3e048",
+        "predicate_id": "RO:0002326",
+        "publications": [],
+        "relation": [
+          "RO:0004013",
+          "RO:0004013"
+        ],
+        "relation_label": [
+          "is causal germline mutation in",
+          "is causal germline mutation in"
+        ],
+        "source_database": [
+          "biolink",
+          "biolink"
+        ],
+        "source_id": "HGNC:16361",
+        "target_id": "MONDO:0019588",
+        "type": "contributes_to"
+      },
+      {
+        "ctime": [
+          1573160645.147381
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "9afb31bdde377b93466d44301a1a759e",
+        "predicate_id": "RO:0002410",
+        "publications": [
+          "PMID:15841483",
+          "PMID:12833159",
+          "PMID:11973626"
+        ],
+        "relation": [
+          "RO:0003303"
+        ],
+        "relation_label": [
+          "causes condition"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:16361",
+        "target_id": "MONDO:0019588",
+        "type": "causes"
+      },
+      {
+        "ctime": [
+          1573160548.97309,
+          1572916738.9330637
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene",
+          "biolink.gene_get_disease"
+        ],
+        "id": "509d26c1dd7a0517c73d4cbe8f4b7bf7",
+        "predicate_id": "RO:0002326",
+        "publications": [],
+        "relation": [
+          "RO:0004013",
+          "RO:0004013"
+        ],
+        "relation_label": [
+          "is causal germline mutation in",
+          "is causal germline mutation in"
+        ],
+        "source_database": [
+          "biolink",
+          "biolink"
+        ],
+        "source_id": "HGNC:30922",
+        "target_id": "MONDO:0019502",
+        "type": "contributes_to"
+      },
+      {
+        "ctime": [
+          1573160548.9731367
+        ],
+        "edge_source": [
+          "biolink.disease_get_gene"
+        ],
+        "id": "2c12d05820535e0cfbe7222f667cbc5a",
+        "predicate_id": "RO:0002410",
+        "publications": [
+          "PMID:21937992",
+          "PMID:23773660"
+        ],
+        "relation": [
+          "RO:0003303"
+        ],
+        "relation_label": [
+          "causes condition"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:30922",
+        "target_id": "MONDO:0019502",
+        "type": "causes"
+      },
+      {
+        "ctime": [
+          1573161155.6697257
+        ],
+        "edge_source": [
+          "pharos.disease_get_gene"
+        ],
+        "id": "8e9e80763f608f704ea1dc7613b29e83",
+        "predicate_id": "NCIT:R176",
+        "publications": [],
+        "relation": [
+          "PHAROS:gene_involved"
+        ],
+        "relation_label": [
+          "gene_involved"
+        ],
+        "source_database": [
+          "pharos"
+        ],
+        "source_id": "MONDO:0020380",
+        "target_id": "HGNC:7897",
+        "type": "disease_to_gene_association"
+      },
+      {
+        "ctime": [
+          1572916739.0255823
+        ],
+        "edge_source": [
+          "hetio.gene_to_disease"
+        ],
+        "id": "e65116e66807b5fc3f15135346e5a4d0",
+        "predicate_id": "RO:0002450",
+        "publications": [],
+        "relation": [
+          "hetio:UPREGULATES_DuG"
+        ],
+        "relation_label": [
+          "UPREGULATES_DuG"
+        ],
+        "source_database": [
+          "hetio"
+        ],
+        "source_id": "MONDO:0011849",
+        "target_id": "HGNC:30922",
+        "type": "positively_regulates__entity_to_entity"
+      },
+      {
+        "ctime": [
+          1572890267.6580265
+        ],
+        "edge_source": [
+          "hetio.gene_to_disease"
+        ],
+        "id": "a1512f83f35f1cc262091d011778e2a5",
+        "predicate_id": "RO:0002449",
+        "publications": [],
+        "relation": [
+          "hetio:DOWNREGULATES_DdG"
+        ],
+        "relation_label": [
+          "DOWNREGULATES_DdG"
+        ],
+        "source_database": [
+          "hetio"
+        ],
+        "source_id": "MONDO:0011849",
+        "target_id": "HGNC:29249",
+        "type": "negatively_regulates__entity_to_entity"
+      },
+      {
+        "ctime": [
+          1572916740.9727342
+        ],
+        "edge_source": [
+          "pharos.gene_get_disease"
+        ],
+        "id": "e4b13787609c5d597952ddbab2ad965e",
+        "predicate_id": "NCIT:R176",
+        "publications": [],
+        "relation": [
+          "PHAROS:gene_involved"
+        ],
+        "relation_label": [
+          "gene_involved"
+        ],
+        "source_database": [
+          "pharos"
+        ],
+        "source_id": "MONDO:0013702",
+        "target_id": "HGNC:30922",
+        "type": "disease_to_gene_association"
+      },
+      {
+        "ctime": [
+          1572909411.9000907
+        ],
+        "edge_source": [
+          "pharos.gene_get_disease"
+        ],
+        "id": "e61eb002c27c93c42bbfd68ade1d458e",
+        "predicate_id": "NCIT:R176",
+        "publications": [],
+        "relation": [
+          "PHAROS:gene_involved"
+        ],
+        "relation_label": [
+          "gene_involved"
+        ],
+        "source_database": [
+          "pharos"
+        ],
+        "source_id": "MONDO:0010017",
+        "target_id": "HGNC:7897",
+        "type": "disease_to_gene_association"
+      },
+      {
+        "ctime": [
+          1572909411.9003422
+        ],
+        "edge_source": [
+          "pharos.gene_get_disease"
+        ],
+        "id": "2304a77d980e4e49701abec01fe7cf95",
+        "predicate_id": "NCIT:R176",
+        "publications": [],
+        "relation": [
+          "PHAROS:gene_involved"
+        ],
+        "relation_label": [
+          "gene_involved"
+        ],
+        "source_database": [
+          "pharos"
+        ],
+        "source_id": "MONDO:0018982",
+        "target_id": "HGNC:7897",
+        "type": "disease_to_gene_association"
+      },
+      {
+        "ctime": [
+          1572914329.8830545
+        ],
+        "edge_source": [
+          "hetio.gene_to_disease"
+        ],
+        "id": "9ab321d0a231b1418f9d2ef1910d3df0",
+        "predicate_id": "RO:0002449",
+        "publications": [],
+        "relation": [
+          "hetio:DOWNREGULATES_DdG"
+        ],
+        "relation_label": [
+          "DOWNREGULATES_DdG"
+        ],
+        "source_database": [
+          "hetio"
+        ],
+        "source_id": "MONDO:0011849",
+        "target_id": "HGNC:24867",
+        "type": "negatively_regulates__entity_to_entity"
+      },
+      {
+        "ctime": [
+          1572909422.228651
+        ],
+        "edge_source": [
+          "biolink.gene_get_phenotype"
+        ],
+        "id": "fa4b08206af858e75510db7f2eec65c1",
+        "predicate_id": "RO:0002200",
+        "publications": [
+          "PMID:16098014",
+          "PMID:17160617",
+          "PMID:18216017",
+          "PMID:11333381",
+          "PMID:25326637",
+          "PMID:10480349",
+          "PMID:27581084",
+          "PMID:9211849",
+          "PMID:28222799",
+          "PMID:23433426",
+          "PMID:25236789",
+          "PMID:12955717",
+          "PMID:26939636",
+          "PMID:27193329",
+          "PMID:25149939",
+          "PMID:26019327",
+          "PMID:16126423",
+          "PMID:9634529",
+          "PMID:25637190",
+          "PMID:12408188",
+          "PMID:12401890",
+          "PMID:11349231",
+          "PMID:15774455",
+          "PMID:11182931",
+          "PMID:11479732",
+          "PMID:28130309",
+          "PMID:15596783",
+          "PMID:23773996",
+          "PMID:11545687",
+          "PMID:12719428",
+          "PMID:19744920",
+          "PMID:19223215",
+          "PMID:23142039",
+          "PMID:4795418",
+          "PMID:26666848",
+          "PMID:24915861",
+          "PMID:23427322",
+          "PMID:10521297",
+          "PMID:20718790",
+          "PMID:19252935",
+          "PMID:11754101",
+          "PMID:12554680",
+          "PMID:20521171",
+          "PMID:10521290",
+          "PMID:16778374"
+        ],
+        "relation": [
+          "RO:0002200"
+        ],
+        "relation_label": [
+          "has phenotype"
+        ],
+        "source_database": [
+          "biolink"
+        ],
+        "source_id": "HGNC:7897",
+        "target_id": "MONDO:0010017",
+        "type": "has_phenotype"
+      },
+      {
+        "ctime": [
+          1572909411.9016628
+        ],
+        "edge_source": [
+          "pharos.gene_get_disease"
+        ],
+        "id": "4307c21780ba9435f2ec841186fc1aef",
+        "predicate_id": "NCIT:R176",
+        "publications": [],
+        "relation": [
+          "PHAROS:gene_involved"
+        ],
+        "relation_label": [
+          "gene_involved"
+        ],
+        "source_database": [
+          "pharos"
+        ],
+        "source_id": "MONDO:0009757",
+        "target_id": "HGNC:7897",
+        "type": "disease_to_gene_association"
+      },
+      {
+        "ctime": [
+          1572931709.119104
+        ],
+        "edge_source": [
+          "pharos.gene_get_disease"
+        ],
+        "id": "790d09ff1574537211b1ab2061d7178d",
+        "predicate_id": "NCIT:R176",
+        "publications": [],
+        "relation": [
+          "PHAROS:gene_involved"
+        ],
+        "relation_label": [
+          "gene_involved"
+        ],
+        "source_database": [
+          "pharos"
+        ],
+        "source_id": "MONDO:0012662",
+        "target_id": "HGNC:16361",
+        "type": "disease_to_gene_association"
+      },
+      {
+        "ctime": [
+          1572931709.1192222
+        ],
+        "edge_source": [
+          "pharos.gene_get_disease"
+        ],
+        "id": "c73e3bd1ebda18b810e05ee4acb35def",
+        "predicate_id": "NCIT:R176",
+        "publications": [],
+        "relation": [
+          "PHAROS:gene_involved"
+        ],
+        "relation_label": [
+          "gene_involved"
+        ],
+        "source_database": [
+          "pharos"
+        ],
+        "source_id": "MONDO:0011767",
+        "target_id": "HGNC:16361",
+        "type": "disease_to_gene_association"
+      }
+    ],
+    "nodes": [
+      {
+        "equivalent_identifiers": [
+          "MONDO:0019245",
+          "ORPHANET:79204",
+          "DOID:9455",
+          "UMLS:CN205834"
+        ],
+        "id": "MONDO:0019245",
+        "name": "lysosomal lipid storage disorder",
+        "nutritional_or_metabolic_disease": true,
+        "synonyms": [
+          "inborn error of lipid storage",
+          "inborn lipid storage disorder",
+          "lipid storage disease",
+          "lipoid storage diseas",
+          "lipoid storage disease",
+          "lipoid storage disorder",
+          "rare inborn error of lipid storage",
+          "lipidoses",
+          "lipidosis",
+          "lipoidoses",
+          "lipoidosis"
+        ],
+        "type": [
+          "genetic_condition",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ]
+      },
+      {
+        "chromosome": "15",
+        "description": "lines homolog 1 [Source:HGNC Symbol;Acc:HGNC:30922]",
+        "end_position": 100603230,
+        "ensembl_name": "LINS1",
+        "equivalent_identifiers": [
+          "UniProtKB:Q8NG48",
+          "ENSEMBL:ENSG00000140471",
+          "HGNC:30922",
+          "HGNC.SYMBOL:LINS1",
+          "HGNC:30922",
+          "NCBIGENE:55180"
+        ],
+        "gene_biotype": "protein_coding",
+        "id": "HGNC:30922",
+        "location": "15q26.3",
+        "locus_group": "protein-coding gene",
+        "name": "LINS1",
+        "start_position": 100559369,
+        "synonyms": [],
+        "taxon": 9606,
+        "type": [
+          "gene",
+          "gene_or_gene_product"
+        ]
+      },
+      {
+        "chromosome": "18",
+        "description": "NPC intracellular cholesterol transporter 1 [Source:HGNC Symbol;Acc:HGNC:7897]",
+        "end_position": 23586506,
+        "ensembl_name": "NPC1",
+        "equivalent_identifiers": [
+          "ENSEMBL:ENSG00000141458",
+          "IUPHAR:3051",
+          "HGNC:7897",
+          "HGNC:7897",
+          "NCBIGENE:4864",
+          "HGNC.SYMBOL:NPC1",
+          "UniProtKB:O15118"
+        ],
+        "gene_biotype": "protein_coding",
+        "gene_family": [
+          "Solute carriers"
+        ],
+        "gene_family_id": [
+          752
+        ],
+        "id": "HGNC:7897",
+        "location": "18q11.2",
+        "locus_group": "protein-coding gene",
+        "name": "NPC1",
+        "start_position": 23506184,
+        "synonyms": [],
+        "taxon": 9606,
+        "type": [
+          "gene",
+          "gene_or_gene_product"
+        ]
+      },
+      {
+        "equivalent_identifiers": [
+          "UMLS:CN205539",
+          "MONDO:0019058",
+          "ORPHANET:68385"
+        ],
+        "id": "MONDO:0019058",
+        "name": "neurometabolic disease",
+        "synonyms": [],
+        "type": [
+          "genetic_condition",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ]
+      },
+      {
+        "equivalent_identifiers": [
+          "ORPHANET:98666",
+          "MONDO:0020244"
+        ],
+        "id": "MONDO:0020244",
+        "name": "unclassified primitive or secondary maculopathy",
+        "synonyms": [],
+        "type": [
+          "genetic_condition",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ]
+      },
+      {
+        "equivalent_identifiers": [
+          "UMLS:CN852731",
+          "DOID:0060230",
+          "UMLS:C0393589",
+          "MONDO:0008947",
+          "ORPHANET:1980"
+        ],
+        "id": "MONDO:0008947",
+        "name": "bilateral striopallidodentate calcinosis",
+        "psychiatric_disorder": true,
+        "synonyms": [
+          "basal ganglia calcification",
+          "basal ganglia calcification, idiopathic, type 1",
+          "basal ganglia degeneration with calcification",
+          "BSPDC",
+          "cerebrovascular ferrocalcinosis",
+          "idiopathic basal ganglia calcification",
+          "idiopathic basal ganglia calcification 1",
+          "PFBC",
+          "primary familial brain calcification",
+          "basal ganglia calcification, idiopathic",
+          "basal ganglia calcification, idiopathic, 1",
+          "IBGC1"
+        ],
+        "type": [
+          "genetic_condition",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ]
+      },
+      {
+        "equivalent_identifiers": [
+          "ORPHANET:371442",
+          "MONDO:0018299"
+        ],
+        "id": "MONDO:0018299",
+        "name": "sphingolipidosis with epilepsy",
+        "nutritional_or_metabolic_disease": true,
+        "synonyms": [],
+        "type": [
+          "genetic_condition",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ]
+      },
+      {
+        "autosomal_genetic_disease": true,
+        "autosomal_recessive_disease": true,
+        "equivalent_identifiers": [
+          "MONDO:0018982",
+          "UMLS:C0220756",
+          "ORPHANET:646"
+        ],
+        "id": "MONDO:0018982",
+        "monogenic_disease": true,
+        "name": "Niemann-Pick disease type C",
+        "nutritional_or_metabolic_disease": true,
+        "psychiatric_disorder": true,
+        "synonyms": [],
+        "systemic_or_rheumatic_disease": true,
+        "type": [
+          "genetic_condition",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ]
+      },
+      {
+        "X_linked_disease": true,
+        "congenital_abnormality": true,
+        "equivalent_identifiers": [
+          "MONDO:0010383",
+          "ORPHANET:908",
+          "DOID:14261",
+          "MEDDRA:10017324",
+          "UMLS:C0016667",
+          "UMLS:C0751156"
+        ],
+        "id": "MONDO:0010383",
+        "monogenic_disease": true,
+        "name": "fragile X syndrome",
+        "nutritional_or_metabolic_disease": true,
+        "psychiatric_disorder": true,
+        "syndromic_disease": true,
+        "synonyms": [
+          "fragile X mental retardation syndrome",
+          "FraX syndrome",
+          "FRAXA syndrome",
+          "FXS",
+          "marker X syndrome",
+          "Martin-Bell syndrome",
+          "fra(X) syndrome",
+          "fragile 10 mental retardation syndrome",
+          "fragile 10 premature ovarian failure",
+          "fragile 10 syndrome",
+          "fragile X syndrome; FXS",
+          "marker 10 syndrome",
+          "mental retardation, X-linked, associated with Marxq28",
+          "primary ovarian insufficiency, fragile X-associated",
+          "X-linked mental retardation and macroorchidism"
+        ],
+        "type": [
+          "genetic_condition",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ]
+      },
+      {
+        "autosomal_genetic_disease": true,
+        "autosomal_recessive_disease": true,
+        "equivalent_identifiers": [
+          "MONDO:0016308",
+          "ORPHANET:216978",
+          "UMLS:CN201114"
+        ],
+        "id": "MONDO:0016308",
+        "monogenic_disease": true,
+        "name": "Niemann-Pick disease type C, late infantile neurologic onset",
+        "nutritional_or_metabolic_disease": true,
+        "psychiatric_disorder": true,
+        "synonyms": [],
+        "systemic_or_rheumatic_disease": true,
+        "type": [
+          "genetic_condition",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ]
+      },
+      {
+        "autosomal_genetic_disease": true,
+        "autosomal_recessive_disease": true,
+        "equivalent_identifiers": [
+          "EFO:1000017",
+          "UMLS:C0265388",
+          "DOID:0050737",
+          "MONDO:0006025"
+        ],
+        "id": "MONDO:0006025",
+        "monogenic_disease": true,
+        "name": "autosomal recessive disease",
+        "synonyms": [
+          "autosomal recessive disease or disorder",
+          "autosomal recessive hereditary disease",
+          "autosomal recessive hereditary disorder",
+          "autosomal recessive inherited disease",
+          "autosomal recessive inherited disorder",
+          "disease or disorder, autosomal recessive",
+          "disease, autosomal recessive",
+          "recessive hereditary disorder (autosomal)"
+        ],
+        "type": [
+          "genetic_condition",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ]
+      },
+      {
+        "equivalent_identifiers": [
+          "UMLS:CN201328",
+          "ORPHANET:225681",
+          "MONDO:0016397"
+        ],
+        "id": "MONDO:0016397",
+        "name": "lysosomal disease with epilepsy",
+        "nutritional_or_metabolic_disease": true,
+        "synonyms": [],
+        "type": [
+          "genetic_condition",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ]
+      },
+      {
+        "equivalent_identifiers": [
+          "UMLS:C0017083",
+          "DOID:2368",
+          "MONDO:0017719",
+          "ORPHANET:309144"
+        ],
+        "id": "MONDO:0017719",
+        "name": "gangliosidosis",
+        "nutritional_or_metabolic_disease": true,
+        "synonyms": [
+          "mucolipidosis type IV"
+        ],
+        "type": [
+          "genetic_condition",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ]
+      },
+      {
+        "chromosome": "14",
+        "description": "Ral GTPase activating protein catalytic alpha subunit 1 [Source:HGNC Symbol;Acc:HGNC:17770]",
+        "end_position": 35809304,
+        "ensembl_name": "RALGAPA1",
+        "equivalent_identifiers": [
+          "HGNC.SYMBOL:RALGAPA1",
+          "UniProtKB:Q6GYQ0",
+          "HGNC:17770",
+          "NCBIGENE:253959",
+          "ENSEMBL:ENSG00000174373",
+          "HGNC:17770"
+        ],
+        "gene_biotype": "protein_coding",
+        "id": "HGNC:17770",
+        "location": "14q13.2",
+        "locus_group": "protein-coding gene",
+        "name": "RALGAPA1",
+        "start_position": 35538352,
+        "synonyms": [],
+        "taxon": 9606,
+        "type": [
+          "gene",
+          "gene_or_gene_product"
+        ]
+      },
+      {
+        "chromosome": "3",
+        "description": "leucine rich repeat containing 15 [Source:HGNC Symbol;Acc:HGNC:20818]",
+        "end_position": 194369743,
+        "ensembl_name": "LRRC15",
+        "equivalent_identifiers": [
+          "HGNC.SYMBOL:LRRC15",
+          "ENSEMBL:ENSG00000172061",
+          "NCBIGENE:131578",
+          "UniProtKB:Q8TF66",
+          "HGNC:20818",
+          "HGNC:20818"
+        ],
+        "gene_biotype": "protein_coding",
+        "id": "HGNC:20818",
+        "location": "3q29",
+        "locus_group": "protein-coding gene",
+        "name": "LRRC15",
+        "start_position": 194355247,
+        "synonyms": [],
+        "taxon": 9606,
+        "type": [
+          "gene",
+          "gene_or_gene_product"
+        ]
+      },
+      {
+        "autosomal_dominant_disease": true,
+        "autosomal_genetic_disease": true,
+        "congenital_abnormality": true,
+        "degenerative_disorder": true,
+        "equivalent_identifiers": [
+          "MEDDRA:10008025",
+          "MEDDRA:10057660",
+          "MESH:D020754",
+          "MONDO:0020380",
+          "UMLS:CN227858",
+          "ORPHANET:99",
+          "DOID:1441",
+          "MONDO:0000437",
+          "MEDDRA:10003592",
+          "ORPHANET:102002",
+          "UMLS:C0007758",
+          "UMLS:C0087012",
+          "DOID:0050753"
+        ],
+        "id": "MONDO:0020380",
+        "monogenic_disease": true,
+        "name": "autosomal dominant cerebellar ataxia",
+        "psychiatric_disorder": true,
+        "syndromic_disease": true,
+        "synonyms": [
+          "ADCA",
+          "autosomal dominant spinocerebellar ataxia",
+          "cerebellar ataxia, autosomal dominant",
+          "Pierre Marie cerebellar ataxia (formerly)",
+          "ataxia",
+          "ataxia syndrome",
+          "spinocerebellar Degeneration",
+          "ataxia, cerebellar",
+          "ataxias, cerebellar",
+          "cerebellar Ataxias",
+          "cerebellar dysmetria",
+          "cerebellar Dysmetrias",
+          "rare ataxia"
+        ],
+        "type": [
+          "genetic_condition",
+          "disease",
+          "disease_or_phenotypic_feature",
+          "phenotypic_feature"
+        ]
+      },
+      {
+        "autosomal_genetic_disease": true,
+        "autosomal_recessive_disease": true,
+        "equivalent_identifiers": [
+          "UMLS:C3179455",
+          "DOID:0070113",
+          "MONDO:0009757"
+        ],
+        "id": "MONDO:0009757",
+        "monogenic_disease": true,
+        "name": "Niemann-Pick disease, type C1",
+        "nutritional_or_metabolic_disease": true,
+        "psychiatric_disorder": true,
+        "synonyms": [
+          "Niemann-Pick disease, type C1",
+          "type C1 Niemann-Pick disease",
+          "Niemann-Pick disease with cholesterol esterification block",
+          "Niemann-Pick disease, subacute juvenile form",
+          "neurovisceral storage disease with vertical supranuclear ophthalmoplegia",
+          "Niemann-Pick disease type C1",
+          "Niemann-Pick disease without sphingomyelinase deficiency",
+          "Niemann-Pick disease, chronic neuronopathic form",
+          "Niemann-Pick disease, nova Scotian type",
+          "Niemann-Pick disease, type C",
+          "Niemann-PICK disease, type C1; NPC1",
+          "Niemann-Pick disease, type D",
+          "NPC1"
+        ],
+        "systemic_or_rheumatic_disease": true,
+        "type": [
+          "genetic_condition",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ]
+      },
+      {
+        "autosomal_genetic_disease": true,
+        "autosomal_recessive_disease": true,
+        "congenital_abnormality": true,
+        "equivalent_identifiers": [
+          "MONDO:0016484",
+          "DOID:0110827",
+          "ORPHANET:231178",
+          "UMLS:C0339534",
+          "UMLS:C1568249"
+        ],
+        "id": "MONDO:0016484",
+        "monogenic_disease": true,
+        "name": "Usher syndrome type 2",
+        "syndromic_disease": true,
+        "synonyms": [
+          "USH2"
+        ],
+        "type": [
+          "genetic_condition",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ]
+      },
+      {
+        "autosomal_genetic_disease": true,
+        "autosomal_recessive_disease": true,
+        "equivalent_identifiers": [
+          "DOID:14504",
+          "EFO:1001380",
+          "MEDDRA:10029403",
+          "MEDDRA:10041515",
+          "UMLS:C0028064",
+          "MONDO:0001982"
+        ],
+        "id": "MONDO:0001982",
+        "monogenic_disease": true,
+        "name": "Niemann-Pick disease",
+        "nutritional_or_metabolic_disease": true,
+        "synonyms": [
+          "lipoid histiocytosis",
+          "lipoid histiocytosis (classical phosphatide)",
+          "Niemann-Pick disease with cholesterol esterification block",
+          "Niemann-Pick disease, subacute juvenile form",
+          "sphingomyelin lipidosis",
+          "sphingomyelin/cholesterol lipidosis",
+          "sphingomyelinase deficiency disease"
+        ],
+        "systemic_or_rheumatic_disease": true,
+        "type": [
+          "genetic_condition",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ]
+      },
+      {
+        "equivalent_identifiers": [
+          "MEDDRA:10055245",
+          "ORPHANET:319218",
+          "UMLS:C0282687",
+          "DOID:4325",
+          "MEDDRA:10014071",
+          "EFO:0007243",
+          "MONDO:0005737",
+          "MEDDRA:10014072",
+          "MEDDRA:10014074"
+        ],
+        "id": "MONDO:0005737",
+        "name": "Ebola hemorrhagic fever",
+        "synonyms": [
+          "Ebola",
+          "Ebola fever",
+          "Ebola virus disease",
+          "Ebolavirus caused disease or disorder",
+          "Ebolavirus disease or disorder",
+          "Ebolavirus infectious disease",
+          "EHF"
+        ],
+        "type": [
+          "disease",
+          "disease_or_phenotypic_feature"
+        ]
+      },
+      {
+        "equivalent_identifiers": [
+          "UMLS:C0238198",
+          "MEDDRA:10051066",
+          "ORPHANET:44890",
+          "DOID:9253",
+          "MONDO:0011719",
+          "MEDDRA:10062427",
+          "MESH:D046152",
+          "UMLS:C3179349"
+        ],
+        "id": "MONDO:0011719",
+        "name": "gastrointestinal stromal tumor",
+        "synonyms": [
+          "gant",
+          "gastrointestinal stromal neoplasm",
+          "gastrointestinal stromal sarcoma",
+          "gastrointestinal stromal tumor",
+          "gastrointestinal stromal tumor (gist)",
+          "gist",
+          "stromal tumor of gastrointestinal tract",
+          "gastrointestinal stromal tumor; gist",
+          "gastrointestinal stromal tumors"
+        ],
+        "type": [
+          "genetic_condition",
+          "disease",
+          "disease_or_phenotypic_feature",
+          "phenotypic_feature"
+        ]
+      },
+      {
+        "autosomal_genetic_disease": true,
+        "autosomal_recessive_disease": true,
+        "equivalent_identifiers": [
+          "UMLS:C1846839",
+          "DOID:0110490",
+          "MONDO:0011767"
+        ],
+        "id": "MONDO:0011767",
+        "monogenic_disease": true,
+        "name": "autosomal recessive nonsyndromic deafness 31",
+        "synonyms": [
+          "autosomal recessive deafness 31",
+          "autosomal recessive nonsyndromic deafness caused by mutation in WHRN",
+          "autosomal recessive nonsyndromic deafness type 31",
+          "deafness, autosomal recessive type 31",
+          "DFNB31",
+          "WHRN autosomal recessive nonsyndromic deafness",
+          "deafness, autosomal recessive 31",
+          "deafness, autosomal recessive 31; DFNB31",
+          "whirler, mouse, homolog of"
+        ],
+        "type": [
+          "genetic_condition",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ]
+      },
+      {
+        "chromosome": "1",
+        "description": "F-box protein 42 [Source:HGNC Symbol;Acc:HGNC:29249]",
+        "end_position": 16352480,
+        "ensembl_name": "FBXO42",
+        "equivalent_identifiers": [
+          "UniProtKB:Q6P3S6",
+          "HGNC:29249",
+          "NCBIGENE:54455",
+          "HGNC.SYMBOL:FBXO42",
+          "HGNC:29249",
+          "ENSEMBL:ENSG00000037637"
+        ],
+        "gene_biotype": "protein_coding",
+        "gene_family": [
+          "F-boxes other"
+        ],
+        "gene_family_id": [
+          560
+        ],
+        "id": "HGNC:29249",
+        "location": "1p36.13",
+        "locus_group": "protein-coding gene",
+        "name": "FBXO42",
+        "start_position": 16246840,
+        "synonyms": [],
+        "taxon": 9606,
+        "type": [
+          "gene",
+          "gene_or_gene_product"
+        ]
+      },
+      {
+        "equivalent_identifiers": [
+          "ORPHANET:98657",
+          "MONDO:0020238",
+          "UMLS:CN207063"
+        ],
+        "id": "MONDO:0020238",
+        "name": "inherited vitreous-retinal disease",
+        "synonyms": [
+          "genetic vitreoretinal disease",
+          "genetic vitreous-retinal disease"
+        ],
+        "type": [
+          "genetic_condition",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ]
+      },
+      {
+        "chromosome": "9",
+        "description": "whirlin [Source:HGNC Symbol;Acc:HGNC:16361]",
+        "end_position": 114505473,
+        "ensembl_name": "WHRN",
+        "equivalent_identifiers": [
+          "NCBIGENE:25861",
+          "HGNC.SYMBOL:WHRN",
+          "UniProtKB:Q9P202",
+          "ENSEMBL:ENSG00000095397",
+          "HGNC:16361",
+          "HGNC:16361"
+        ],
+        "gene_biotype": "protein_coding",
+        "gene_family": [
+          "Deafness associated genes",
+          "PDZ domain containing",
+          "USH2 complex "
+        ],
+        "gene_family_id": [
+          1152,
+          1220,
+          1244
+        ],
+        "id": "HGNC:16361",
+        "location": "9q32",
+        "locus_group": "protein-coding gene",
+        "name": "WHRN",
+        "start_position": 114402080,
+        "synonyms": [],
+        "taxon": 9606,
+        "type": [
+          "gene",
+          "gene_or_gene_product"
+        ]
+      },
+      {
+        "equivalent_identifiers": [
+          "MONDO:0002561",
+          "UMLS:CN205533",
+          "ORPHANET:68366",
+          "MEDDRA:10024579",
+          "DOID:3211",
+          "UMLS:C0085078"
+        ],
+        "id": "MONDO:0002561",
+        "name": "lysosomal storage disease",
+        "nutritional_or_metabolic_disease": true,
+        "synonyms": [
+          "disorder of lysosomal enzyme",
+          "disorder of lysosomal enzymes",
+          "inborn lysosomal enzyme disorder",
+          "lysosomal disease",
+          "lysosomal disorder",
+          "lysosomal storage disorder",
+          "lysosomal storage metabolism disorder",
+          "lysosome disease",
+          "lysosome disorder",
+          "phospholipidosis"
+        ],
+        "type": [
+          "genetic_condition",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ]
+      },
+      {
+        "equivalent_identifiers": [
+          "ORPHANET:98664",
+          "MONDO:0020242"
+        ],
+        "id": "MONDO:0020242",
+        "name": "genetic macular dystrophy",
+        "synonyms": [
+          "genetic macular dystrophy",
+          "genetic macular dystrophy (disease)"
+        ],
+        "type": [
+          "genetic_condition",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ]
+      },
+      {
+        "disease_susceptibility": true,
+        "equivalent_identifiers": [
+          "MEDDRA:10037160",
+          "MEDDRA:10003377",
+          "MEDDRA:10037162",
+          "UMLS:C0003872",
+          "DOID:9008",
+          "MEDDRA:10037163",
+          "MONDO:0011849",
+          "EFO:0003778"
+        ],
+        "id": "MONDO:0011849",
+        "name": "psoriatic arthritis",
+        "syndromic_disease": true,
+        "synonyms": [
+          "arthritis psoriatica",
+          "arthropathic psoriasis",
+          "psoriatic arthritis, susceptibility to",
+          "psoriatic arthritis, susceptibility to, 1",
+          "psoriatic arthropathy",
+          "susceptibility to psoriatic arthritis"
+        ],
+        "type": [
+          "genetic_condition",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ]
+      },
+      {
+        "equivalent_identifiers": [
+          "MESH:D058499",
+          "UMLS:C0154860",
+          "UMLS:C0854723",
+          "MEDDRA:10019900",
+          "MONDO:0019118",
+          "MEDDRA:10019899",
+          "ORPHANET:71862",
+          "MEDDRA:10038857",
+          "MEDDRA:10019898",
+          "DOID:8500",
+          "DOID:8501"
+        ],
+        "id": "MONDO:0019118",
+        "name": "inherited retinal dystrophy",
+        "synonyms": [
+          "familial retinal dystrophy",
+          "genetic retinal dystrophy",
+          "hereditary retinal degeneration",
+          "hereditary retinal dystrophy",
+          "retinal dystrophy"
+        ],
+        "type": [
+          "genetic_condition",
+          "disease",
+          "disease_or_phenotypic_feature",
+          "phenotypic_feature"
+        ]
+      },
+      {
+        "equivalent_identifiers": [
+          "UMLS:CN202531",
+          "ORPHANET:271870",
+          "MONDO:0017133"
+        ],
+        "id": "MONDO:0017133",
+        "name": "genetic systemic or rheumatologic disease",
+        "synonyms": [
+          "hereditary systemic or rheumatic disease"
+        ],
+        "systemic_or_rheumatic_disease": true,
+        "type": [
+          "genetic_condition",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ]
+      },
+      {
+        "X_linked_disease": true,
+        "congenital_abnormality": true,
+        "equivalent_identifiers": [
+          "UMLS:C1844678",
+          "EFO:1001176",
+          "DOID:10003",
+          "MONDO:0010576",
+          "ORPHANET:383",
+          "MONDO:0011080",
+          "UMLS:C1832354",
+          "ORPHANET:3235"
+        ],
+        "id": "MONDO:0010576",
+        "monogenic_disease": true,
+        "name": "X-linked mixed deafness with perilymphatic gusher",
+        "syndromic_disease": true,
+        "synonyms": [
+          "Stapedo-vestibular ankylosis",
+          "Thies-Reis syndrome",
+          "deafness, progressive, with stapes fixation",
+          "Thies Reis syndrome",
+          "conductive deafness with stapes fixation",
+          "deafness mixed with perilymphatic gusher, X-linked",
+          "deafness, X-linked type 2",
+          "DFNX2",
+          "Nance deafness",
+          "X-linked deafness type 2",
+          "X-linked mixed conductive and neurosensory deafness",
+          "X-linked mixed conductive and neurosensory hearing loss",
+          "X-linked mixed conductive and sensorineural deafness",
+          "X-linked mixed conductive and sensorineural hearing loss",
+          "X-linked stapes gusher syndrome",
+          "deafness 3 conductive with stapes fixation",
+          "deafness 3, conductive, with stapes fixation",
+          "deafness conductive with stapes fixation",
+          "deafness mixed with perilymphatic gusher",
+          "deafness, conductive, with stapes fixation",
+          "deafness, mixed, with perilymphatic gusher",
+          "deafness, X-linked 2",
+          "deafness, X-linked 2; DFNX2",
+          "DFN 3 nonsyndromic hearing loss and deafness",
+          "DFN3",
+          "gusher syndrome",
+          "perilymphatic gusher-deafness syndrome",
+          "sensorineural deafness, profound, with or without a conductive component, associated with a unique developmental Abnormality of the Ear"
+        ],
+        "type": [
+          "genetic_condition",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ]
+      },
+      {
+        "X_linked_disease": true,
+        "congenital_abnormality": true,
+        "equivalent_identifiers": [
+          "UMLS:C1844678",
+          "EFO:1001176",
+          "DOID:10003",
+          "MONDO:0010576",
+          "ORPHANET:383",
+          "MONDO:0011080",
+          "UMLS:C1832354",
+          "ORPHANET:3235"
+        ],
+        "id": "MONDO:0011080",
+        "monogenic_disease": true,
+        "name": "progressive deafness with stapes fixation",
+        "syndromic_disease": true,
+        "synonyms": [
+          "Stapedo-vestibular ankylosis",
+          "Thies-Reis syndrome",
+          "deafness, progressive, with stapes fixation",
+          "Thies Reis syndrome",
+          "conductive deafness with stapes fixation",
+          "deafness mixed with perilymphatic gusher, X-linked",
+          "deafness, X-linked type 2",
+          "DFNX2",
+          "Nance deafness",
+          "X-linked deafness type 2",
+          "X-linked mixed conductive and neurosensory deafness",
+          "X-linked mixed conductive and neurosensory hearing loss",
+          "X-linked mixed conductive and sensorineural deafness",
+          "X-linked mixed conductive and sensorineural hearing loss",
+          "X-linked stapes gusher syndrome",
+          "deafness 3 conductive with stapes fixation",
+          "deafness 3, conductive, with stapes fixation",
+          "deafness conductive with stapes fixation",
+          "deafness mixed with perilymphatic gusher",
+          "deafness, conductive, with stapes fixation",
+          "deafness, mixed, with perilymphatic gusher",
+          "deafness, X-linked 2",
+          "deafness, X-linked 2; DFNX2",
+          "DFN 3 nonsyndromic hearing loss and deafness",
+          "DFN3",
+          "gusher syndrome",
+          "perilymphatic gusher-deafness syndrome",
+          "sensorineural deafness, profound, with or without a conductive component, associated with a unique developmental Abnormality of the Ear"
+        ],
+        "type": [
+          "genetic_condition",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ]
+      },
+      {
+        "equivalent_identifiers": [
+          "UMLS:C0154251",
+          "DOID:3146",
+          "MEDDRA:10045841",
+          "MEDDRA:10024582",
+          "MEDDRA:10013317",
+          "ORPHANET:309005",
+          "MEDDRA:10016245",
+          "MONDO:0002525",
+          "MEDDRA:10045807",
+          "MEDDRA:10061227",
+          "MEDDRA:10013318"
+        ],
+        "id": "MONDO:0002525",
+        "name": "inherited lipid metabolism disorder",
+        "nutritional_or_metabolic_disease": true,
+        "synonyms": [
+          "fatty acid metabolism disorder"
+        ],
+        "type": [
+          "genetic_condition",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ]
+      },
+      {
+        "equivalent_identifiers": [
+          "MONDO:0020240",
+          "ORPHANET:98661",
+          "UMLS:CN227834"
+        ],
+        "id": "MONDO:0020240",
+        "name": "syndromic retinitis pigmentosa",
+        "syndromic_disease": true,
+        "synonyms": [
+          "syndrome associated with retinitis pigmentosa",
+          "syndromic retinitis pigmentosa"
+        ],
+        "type": [
+          "genetic_condition",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ]
+      },
+      {
+        "equivalent_identifiers": [
+          "UMLS:CN200063",
+          "ORPHANET:166472",
+          "MONDO:0015653"
+        ],
+        "id": "MONDO:0015653",
+        "monogenic_disease": true,
+        "name": "monogenic disease with epilepsy",
+        "synonyms": [],
+        "type": [
+          "genetic_condition",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ]
+      },
+      {
+        "equivalent_identifiers": [
+          "UMLS:CN227174",
+          "UMLS:CN227173",
+          "ORPHANET:307064",
+          "ORPHANET:307061",
+          "MONDO:0017663"
+        ],
+        "id": "MONDO:0017663",
+        "name": "inherited tremor disorder",
+        "synonyms": [
+          "rare genetic myoclonus"
+        ],
+        "type": [
+          "genetic_condition",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ]
+      },
+      {
+        "equivalent_identifiers": [
+          "MONDO:0000275",
+          "DOID:0050177"
+        ],
+        "id": "MONDO:0000275",
+        "monogenic_disease": true,
+        "name": "monogenic disease",
+        "synonyms": [],
+        "type": [
+          "genetic_condition",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ]
+      },
+      {
+        "equivalent_identifiers": [
+          "ORPHANET:98543",
+          "UMLS:CN207023",
+          "MONDO:0020142"
+        ],
+        "id": "MONDO:0020142",
+        "name": "metabolic disease with dementia",
+        "nutritional_or_metabolic_disease": true,
+        "psychiatric_disorder": true,
+        "synonyms": [],
+        "type": [
+          "genetic_condition",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ]
+      },
+      {
+        "autosomal_genetic_disease": true,
+        "autosomal_recessive_disease": true,
+        "equivalent_identifiers": [
+          "MONDO:0019502",
+          "DOID:0060308",
+          "ORPHANET:88616",
+          "UMLS:CN206293"
+        ],
+        "id": "MONDO:0019502",
+        "monogenic_disease": true,
+        "name": "autosomal recessive non-syndromic intellectual disability",
+        "psychiatric_disorder": true,
+        "synonyms": [
+          "AR-NSID",
+          "autosomal recessive mental retardation",
+          "autosomal recessive non-syndromic mental retardation",
+          "mental retardation, autosomal recessive",
+          "non-syndromic intellectual disability, autosomal recessive",
+          "NS-ARID"
+        ],
+        "type": [
+          "genetic_condition",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ]
+      },
+      {
+        "equivalent_identifiers": [
+          "MEDDRA:10054856",
+          "ORPHANET:791",
+          "UMLS:C0035334",
+          "MONDO:0019200",
+          "DOID:10584",
+          "MEDDRA:10038914",
+          "UMLS:C4072872"
+        ],
+        "id": "MONDO:0019200",
+        "name": "retinitis pigmentosa",
+        "synonyms": [
+          "Rod-cone dystrophy"
+        ],
+        "type": [
+          "genetic_condition",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ]
+      },
+      {
+        "autosomal_genetic_disease": true,
+        "autosomal_recessive_disease": true,
+        "equivalent_identifiers": [
+          "DOID:0050565",
+          "UMLS:CN206424",
+          "ORPHANET:90636",
+          "MONDO:0019588",
+          "UMLS:C1846647"
+        ],
+        "id": "MONDO:0019588",
+        "monogenic_disease": true,
+        "name": "autosomal recessive nonsyndromic deafness",
+        "synonyms": [
+          "autosomal recessive isolated neurosensory deafness type DFNB",
+          "autosomal recessive isolated sensorineural deafness type DFNB",
+          "autosomal recessive non-syndromic neurosensory deafness type DFNB",
+          "autosomal recessive nonsyndromic genetic deafness",
+          "deafness, autosomal recessive",
+          "nonsyndromic deafness, autosomal recessive",
+          "nonsyndromic genetic deafness, autosomal recessive",
+          "autosomal recessive non-syndromic sensorineural deafness type DFNB",
+          "deafness, neurosensory nonsyndromic recessive, DFN"
+        ],
+        "type": [
+          "genetic_condition",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ]
+      },
+      {
+        "autosomal_genetic_disease": true,
+        "autosomal_recessive_disease": true,
+        "equivalent_identifiers": [
+          "UMLS:CN201112",
+          "ORPHANET:216972",
+          "MONDO:0016306"
+        ],
+        "id": "MONDO:0016306",
+        "monogenic_disease": true,
+        "name": "Niemann-Pick disease type C, severe perinatal form",
+        "nutritional_or_metabolic_disease": true,
+        "psychiatric_disorder": true,
+        "synonyms": [],
+        "systemic_or_rheumatic_disease": true,
+        "type": [
+          "genetic_condition",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ]
+      },
+      {
+        "equivalent_identifiers": [
+          "MEDDRA:10021601",
+          "MONDO:0019052",
+          "MEDDRA:10062018",
+          "ORPHANET:68367",
+          "UMLS:C0025521",
+          "MEDDRA:10021605",
+          "DOID:655"
+        ],
+        "id": "MONDO:0019052",
+        "name": "inborn errors of metabolism",
+        "nutritional_or_metabolic_disease": true,
+        "synonyms": [
+          "congenital metabolic disorder",
+          "congenital metabolism disorder",
+          "hereditary metabolic disease",
+          "inborn error of metabolism",
+          "inborn errors of metabolism",
+          "inborn metabolism disorder",
+          "inherited metabolic disorder",
+          "metabolic hereditary disorder",
+          "rare metabolic disease"
+        ],
+        "type": [
+          "genetic_condition",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ]
+      },
+      {
+        "autosomal_genetic_disease": true,
+        "autosomal_recessive_disease": true,
+        "congenital_abnormality": true,
+        "equivalent_identifiers": [
+          "UMLS:CN239459",
+          "ORPHANET:2855",
+          "MONDO:0017312",
+          "DOID:0050857",
+          "UMLS:C0685838"
+        ],
+        "id": "MONDO:0017312",
+        "monogenic_disease": true,
+        "name": "Perrault syndrome",
+        "nutritional_or_metabolic_disease": true,
+        "syndromic_disease": true,
+        "synonyms": [
+          "XX gonodal dysgenesis-deafness syndrome",
+          "gonadal dysgenesis, XX type, with deafness"
+        ],
+        "type": [
+          "genetic_condition",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ]
+      },
+      {
+        "degenerative_disorder": true,
+        "equivalent_identifiers": [
+          "ORPHANET:289560",
+          "DOID:0110738",
+          "UMLS:C3280371",
+          "MONDO:0013674"
+        ],
+        "id": "MONDO:0013674",
+        "name": "neurodegeneration with brain iron accumulation 4",
+        "nutritional_or_metabolic_disease": true,
+        "psychiatric_disorder": true,
+        "syndromic_disease": true,
+        "synonyms": [
+          "C19orf12 neurodegeneration with brain iron accumulation",
+          "mitochondrial Protein-associated neurodegeneration",
+          "MPAN",
+          "NBIA due to C19orf12 mutation",
+          "NBIA4",
+          "neurodegeneration with brain iron accumulation 4",
+          "neurodegeneration with brain iron accumulation caused by mutation in C19orf12",
+          "neurodegeneration with brain iron accumulation due to C19orf12 mutation",
+          "neurodegeneration with brain iron accumulation type 4",
+          "mitochondrial membrane protein-associated neurodegeneration",
+          "neurodegeneration with brain iron accumulation 4; NBIA4"
+        ],
+        "type": [
+          "genetic_condition",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ]
+      },
+      {
+        "equivalent_identifiers": [
+          "MONDO:0016297",
+          "ORPHANET:216445"
+        ],
+        "id": "MONDO:0016297",
+        "name": "prelingual non-syndromic genetic deafness",
+        "synonyms": [
+          "isolated prelingual genetic deafness"
+        ],
+        "type": [
+          "genetic_condition",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ]
+      },
+      {
+        "equivalent_identifiers": [
+          "MESH:D012618",
+          "MONDO:0010017",
+          "ORPHANET:158029",
+          "DOID:4423",
+          "EFO:1001170",
+          "UMLS:C0036489"
+        ],
+        "id": "MONDO:0010017",
+        "name": "sea-blue histiocyte syndrome",
+        "nutritional_or_metabolic_disease": true,
+        "syndromic_disease": true,
+        "synonyms": [
+          "histiocytosis, Sea-blue",
+          "inherited Lipemic splenomegaly",
+          "SEA-blue histiocyte disease",
+          "sea-blue histiocytosis"
+        ],
+        "systemic_or_rheumatic_disease": true,
+        "type": [
+          "genetic_condition",
+          "disease",
+          "disease_or_phenotypic_feature",
+          "phenotypic_feature"
+        ]
+      },
+      {
+        "autosomal_genetic_disease": true,
+        "autosomal_recessive_disease": true,
+        "equivalent_identifiers": [
+          "UMLS:CN201113",
+          "ORPHANET:216975",
+          "MONDO:0016307"
+        ],
+        "id": "MONDO:0016307",
+        "monogenic_disease": true,
+        "name": "Niemann-Pick disease type C, severe early infantile neurologic onset",
+        "nutritional_or_metabolic_disease": true,
+        "psychiatric_disorder": true,
+        "synonyms": [],
+        "systemic_or_rheumatic_disease": true,
+        "type": [
+          "genetic_condition",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ]
+      },
+      {
+        "equivalent_identifiers": [
+          "MONDO:0016298",
+          "ORPHANET:216452"
+        ],
+        "id": "MONDO:0016298",
+        "name": "postlingual non-syndromic genetic deafness",
+        "synonyms": [
+          "isolated postlingual genetic deafness"
+        ],
+        "type": [
+          "genetic_condition",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ]
+      },
+      {
+        "degenerative_disorder": true,
+        "equivalent_identifiers": [
+          "MONDO:0019262",
+          "ORPHANET:79264",
+          "DOID:0050756"
+        ],
+        "id": "MONDO:0019262",
+        "name": "juvenile neuronal ceroid lipofuscinosis",
+        "nutritional_or_metabolic_disease": true,
+        "psychiatric_disorder": true,
+        "synonyms": [
+          "batten disease",
+          "juvenile neuronal ceroid lipofuscinosis",
+          "JNCL",
+          "juvenile NCL",
+          "Spielmeyer-Vogt disease"
+        ],
+        "type": [
+          "genetic_condition",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ]
+      },
+      {
+        "equivalent_identifiers": [
+          "UMLS:C0007788",
+          "MONDO:0020143",
+          "ORPHANET:98544",
+          "DOID:10742",
+          "MEDDRA:10008125"
+        ],
+        "id": "MONDO:0020143",
+        "name": "cerebral lipidosis with dementia",
+        "nutritional_or_metabolic_disease": true,
+        "psychiatric_disorder": true,
+        "synonyms": [
+          "cerebral lipidosis"
+        ],
+        "type": [
+          "genetic_condition",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ]
+      },
+      {
+        "chromosome": "19",
+        "description": "URI1 prefoldin like chaperone [Source:HGNC Symbol;Acc:HGNC:13236]",
+        "end_position": 30016612,
+        "ensembl_name": "URI1",
+        "equivalent_identifiers": [
+          "HGNC:13236",
+          "HGNC.SYMBOL:URI1",
+          "HGNC:13236",
+          "UniProtKB:O94763",
+          "ENSEMBL:ENSG00000105176",
+          "NCBIGENE:8725"
+        ],
+        "gene_biotype": "protein_coding",
+        "gene_family": [
+          "Protein phosphatase 1 regulatory subunits",
+          "Prefoldin subunits"
+        ],
+        "gene_family_id": [
+          694,
+          956
+        ],
+        "id": "HGNC:13236",
+        "location": "19q12",
+        "locus_group": "protein-coding gene",
+        "name": "URI1",
+        "start_position": 29923644,
+        "synonyms": [],
+        "taxon": 9606,
+        "type": [
+          "gene",
+          "gene_or_gene_product"
+        ]
+      },
+      {
+        "chromosome": "12",
+        "description": "glycolipid transfer protein [Source:HGNC Symbol;Acc:HGNC:24867]",
+        "end_position": 109880541,
+        "ensembl_name": "GLTP",
+        "equivalent_identifiers": [
+          "UniProtKB:Q9NZD2",
+          "HGNC:24867",
+          "HGNC.SYMBOL:GLTP",
+          "NCBIGENE:51228",
+          "ENSEMBL:ENSG00000139433",
+          "HGNC:24867"
+        ],
+        "gene_biotype": "protein_coding",
+        "id": "HGNC:24867",
+        "location": "12q24.11",
+        "locus_group": "protein-coding gene",
+        "name": "Glycolipid transfer protein",
+        "start_position": 109850945,
+        "synonyms": [],
+        "taxon": 9606,
+        "type": [
+          "gene",
+          "gene_or_gene_product"
+        ]
+      },
+      {
+        "autosomal_genetic_disease": true,
+        "equivalent_identifiers": [
+          "MONDO:0000429",
+          "UMLS:C0265384",
+          "DOID:0050739"
+        ],
+        "id": "MONDO:0000429",
+        "monogenic_disease": true,
+        "name": "autosomal genetic disease",
+        "synonyms": [
+          "autosomal hereditary disorder",
+          "autosomal inherited disease",
+          "autosomal inherited disorder"
+        ],
+        "type": [
+          "genetic_condition",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ]
+      },
+      {
+        "autosomal_genetic_disease": true,
+        "autosomal_recessive_disease": true,
+        "equivalent_identifiers": [
+          "UMLS:C3280538",
+          "MONDO:0013702"
+        ],
+        "id": "MONDO:0013702",
+        "monogenic_disease": true,
+        "name": "intellectual disability, autosomal recessive 27",
+        "psychiatric_disorder": true,
+        "synonyms": [
+          "autosomal recessive non-syndromic intellectual disability caused by mutation in LINS1",
+          "LINS1 autosomal recessive non-syndromic intellectual disability",
+          "mental retardation, autosomal recessive type 27",
+          "mental retardation, autosomal recessive 27",
+          "mental retardation, autosomal recessive 27; MRT27",
+          "MRT27"
+        ],
+        "type": [
+          "genetic_condition",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ]
+      },
+      {
+        "chromosome": "22",
+        "description": "GTP binding protein 1 [Source:HGNC Symbol;Acc:HGNC:4669]",
+        "end_position": 38738299,
+        "ensembl_name": "GTPBP1",
+        "equivalent_identifiers": [
+          "HGNC:4669",
+          "ENSEMBL:ENSG00000100226",
+          "UniProtKB:O00178",
+          "HGNC:4669",
+          "NCBIGENE:9567",
+          "HGNC.SYMBOL:GTPBP1"
+        ],
+        "gene_biotype": "protein_coding",
+        "id": "HGNC:4669",
+        "location": "22q13.1",
+        "locus_group": "protein-coding gene",
+        "name": "GTP-binding protein 1",
+        "start_position": 38705742,
+        "synonyms": [],
+        "taxon": 9606,
+        "type": [
+          "gene",
+          "gene_or_gene_product"
+        ]
+      },
+      {
+        "autosomal_genetic_disease": true,
+        "autosomal_recessive_disease": true,
+        "congenital_abnormality": true,
+        "equivalent_identifiers": [
+          "MONDO:0012662",
+          "DOID:0110840"
+        ],
+        "id": "MONDO:0012662",
+        "monogenic_disease": true,
+        "name": "Usher syndrome type 2D",
+        "syndromic_disease": true,
+        "synonyms": [
+          "USH2D",
+          "Usher syndrome caused by mutation in WHRN",
+          "Usher syndrome type IID",
+          "WHRN Usher syndrome",
+          "Usher syndrome, type 2D",
+          "USHER syndrome, type IID",
+          "USHER syndrome, type IID; USH2D"
+        ],
+        "type": [
+          "genetic_condition",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ]
+      },
+      {
+        "autosomal_genetic_disease": true,
+        "autosomal_recessive_disease": true,
+        "equivalent_identifiers": [
+          "ORPHANET:216986",
+          "UMLS:CN201116",
+          "MONDO:0016310"
+        ],
+        "id": "MONDO:0016310",
+        "monogenic_disease": true,
+        "name": "Niemann-Pick disease type C, adult neurologic onset",
+        "nutritional_or_metabolic_disease": true,
+        "psychiatric_disorder": true,
+        "synonyms": [],
+        "systemic_or_rheumatic_disease": true,
+        "type": [
+          "genetic_condition",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ]
+      },
+      {
+        "autosomal_genetic_disease": true,
+        "autosomal_recessive_disease": true,
+        "congenital_abnormality": true,
+        "equivalent_identifiers": [
+          "MONDO:0019501",
+          "ORPHANET:886",
+          "MEDDRA:10063396",
+          "DOID:0050439",
+          "UMLS:C0271097"
+        ],
+        "id": "MONDO:0019501",
+        "monogenic_disease": true,
+        "name": "Usher syndrome",
+        "syndromic_disease": true,
+        "synonyms": [
+          "retinitis pigmentosa-deafness syndrome",
+          "ush",
+          "deafness-retinitis pigmentosa syndrome",
+          "dystrophia retinae pigmentosa-dysostosis syndrome",
+          "Graefe-Usher syndrome",
+          "Hallgren syndrome",
+          "Usher's syndrome"
+        ],
+        "type": [
+          "genetic_condition",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ]
+      },
+      {
+        "equivalent_identifiers": [
+          "UMLS:CN043648",
+          "DOID:0050563",
+          "EFO:0009076",
+          "ORPHANET:87884",
+          "MONDO:0019497"
+        ],
+        "id": "MONDO:0019497",
+        "name": "nonsyndromic genetic deafness",
+        "synonyms": [
+          "isolated genetic deafness",
+          "nonsyndromic hearing loss",
+          "nonsyndromic hereditary hearing loss",
+          "familial deafness",
+          "non-syndromic genetic deafness",
+          "nonsyndromic deafness"
+        ],
+        "type": [
+          "genetic_condition",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ]
+      },
+      {
+        "equivalent_identifiers": [
+          "DOID:1927",
+          "UMLS:C0037899",
+          "ORPHANET:79225",
+          "MONDO:0019255"
+        ],
+        "id": "MONDO:0019255",
+        "name": "sphingolipidosis",
+        "nutritional_or_metabolic_disease": true,
+        "synonyms": [
+          "sphingolipidoses",
+          "sphingolipidosis, NOS"
+        ],
+        "type": [
+          "genetic_condition",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ]
+      },
+      {
+        "equivalent_identifiers": [
+          "MONDO:0015547",
+          "ORPHANET:158124"
+        ],
+        "id": "MONDO:0015547",
+        "name": "genetic dementia",
+        "psychiatric_disorder": true,
+        "synonyms": [
+          "genetic dementia"
+        ],
+        "type": [
+          "genetic_condition",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ]
+      },
+      {
+        "equivalent_identifiers": [
+          "UMLS:C0410787",
+          "MONDO:0023603"
+        ],
+        "id": "MONDO:0023603",
+        "name": "hereditary connective tissue disorder",
+        "synonyms": [
+          "connective tissue hereditary disorder",
+          "hereditary connective tissue disorder",
+          "Connective tissue hereditary disorder",
+          "Hereditary Connective Tissue Disorder",
+          "inherited disorder of connective tissue",
+          "Inherited disorder of connective tissue"
+        ],
+        "type": [
+          "genetic_condition",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ]
+      },
+      {
+        "congenital_abnormality": true,
+        "equivalent_identifiers": [
+          "UMLS:CN206426",
+          "MONDO:0019589",
+          "ORPHANET:90642"
+        ],
+        "id": "MONDO:0019589",
+        "name": "syndromic genetic deafness",
+        "syndromic_disease": true,
+        "synonyms": [
+          "syndromic hearing loss"
+        ],
+        "type": [
+          "genetic_condition",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ]
+      },
+      {
+        "autosomal_genetic_disease": true,
+        "autosomal_recessive_disease": true,
+        "equivalent_identifiers": [
+          "UMLS:CN201115",
+          "MONDO:0016309",
+          "ORPHANET:216981"
+        ],
+        "id": "MONDO:0016309",
+        "monogenic_disease": true,
+        "name": "Niemann-Pick disease type C, juvenile neurologic onset",
+        "nutritional_or_metabolic_disease": true,
+        "psychiatric_disorder": true,
+        "synonyms": [
+          "Niemann-Pick disease type C, classic form"
+        ],
+        "systemic_or_rheumatic_disease": true,
+        "type": [
+          "genetic_condition",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ]
+      }
+    ]
+  },
+  "query_graph": {
+    "edges": [
+      {
+        "id": "e00",
+        "source_id": "n00",
+        "target_id": "n01"
+      },
+      {
+        "id": "e01",
+        "source_id": "n01",
+        "target_id": "n02"
+      }
+    ],
+    "nodes": [
+      {
+        "curie": "MONDO:0005737",
+        "id": "n00"
+      },
+      {
+        "id": "n01",
+        "type": "gene"
+      },
+      {
+        "id": "n02",
+        "type": "genetic_condition"
+      }
+    ]
+  },
+  "results": [
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "9d176db36fcfb9f359c52062767faa7d",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "21abfcf64d93b48ff888717b09e2ea81",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:17770",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0008947",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "5579d0ec3e69cf5bd79fd643942d8536",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "dcc60e942d1f17e26d73dc5b73016462",
+          "qg_id": "e01"
+        },
+        {
+          "kg_id": "80ac7bb75f91890fa90cbcdd94bd861d",
+          "qg_id": "e01"
+        },
+        {
+          "kg_id": "2304a77d980e4e49701abec01fe7cf95",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:7897",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0018982",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "5579d0ec3e69cf5bd79fd643942d8536",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "57484a4caa299dd55a20f7cd072e18f4",
+          "qg_id": "e01"
+        },
+        {
+          "kg_id": "dfe342b3ca8a213b5684608610bf4311",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:7897",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0006025",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "5579d0ec3e69cf5bd79fd643942d8536",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "22b290072185ddefea142bb8190aea54",
+          "qg_id": "e01"
+        },
+        {
+          "kg_id": "9b892ba625b82b91b42ac79c42df5287",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:7897",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0019118",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "5579d0ec3e69cf5bd79fd643942d8536",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "b4451ab465d13e44c19c4e5703befc90",
+          "qg_id": "e01"
+        },
+        {
+          "kg_id": "3726c1decb208d06bdffe464a68b940e",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:7897",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0019058",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "5579d0ec3e69cf5bd79fd643942d8536",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "8e8ee0341df31126c1ed224a904c90e3",
+          "qg_id": "e01"
+        },
+        {
+          "kg_id": "0639d713dc11b8f59ee56bb3c8b663a0",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:7897",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0019052",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "5579d0ec3e69cf5bd79fd643942d8536",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "9791fbb15863871831688aa2f9eda7af",
+          "qg_id": "e01"
+        },
+        {
+          "kg_id": "54def4d64ef4cdca73611e914dd551a7",
+          "qg_id": "e01"
+        },
+        {
+          "kg_id": "d5c5155df21271424395bf907352723b",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:7897",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0001982",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "5579d0ec3e69cf5bd79fd643942d8536",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "e9d313a77d019672f0c96a8ef14ea0c0",
+          "qg_id": "e01"
+        },
+        {
+          "kg_id": "29af30b5ed34429bc974c8f7c3837415",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:7897",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0019255",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "5579d0ec3e69cf5bd79fd643942d8536",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "26597a2cf6d997bc4e88b80af19b69b2",
+          "qg_id": "e01"
+        },
+        {
+          "kg_id": "2991231517de9621b906b8147adc328a",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:7897",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0019245",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "5579d0ec3e69cf5bd79fd643942d8536",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "674187fabae5f0149ab9ffeb51a6f9fe",
+          "qg_id": "e01"
+        },
+        {
+          "kg_id": "7856edba25fc639d9c9c3f7e9e731334",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:7897",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0015653",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "5579d0ec3e69cf5bd79fd643942d8536",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "b15043dcf00b641e9ab65377f044abf2",
+          "qg_id": "e01"
+        },
+        {
+          "kg_id": "f0c58954ab424612138f2bb6b5f33d54",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:7897",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0018299",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "5579d0ec3e69cf5bd79fd643942d8536",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "0a45559c62f3b853d786f19162b9949f",
+          "qg_id": "e01"
+        },
+        {
+          "kg_id": "4acb507be781eaecf2d588b5963a0129",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:7897",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0015547",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "5579d0ec3e69cf5bd79fd643942d8536",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "ceeead34232032edccaa0e482f149030",
+          "qg_id": "e01"
+        },
+        {
+          "kg_id": "94b610df333552b2291c81385c58b8d6",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:7897",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0023603",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "5579d0ec3e69cf5bd79fd643942d8536",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "2981a9f1d0498b3d0bd251238043d8a6",
+          "qg_id": "e01"
+        },
+        {
+          "kg_id": "12ad8c1cd217e1889ac92873b23b2da9",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:7897",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0002561",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "5579d0ec3e69cf5bd79fd643942d8536",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "a54f731ce79a51c55ed9d2c7a4ba163e",
+          "qg_id": "e01"
+        },
+        {
+          "kg_id": "7e0898c6e19f07399e41642096b1aab9",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:7897",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0000275",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "5579d0ec3e69cf5bd79fd643942d8536",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "f965081529979666a5e30929c2fa689c",
+          "qg_id": "e01"
+        },
+        {
+          "kg_id": "2029951f606490ff949467191cbc8082",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:7897",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0002525",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "5579d0ec3e69cf5bd79fd643942d8536",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "b87e7851c47a2561865fbb328dce1afd",
+          "qg_id": "e01"
+        },
+        {
+          "kg_id": "3ca42696305fd2d60110e24a2c55d489",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:7897",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0017663",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "5579d0ec3e69cf5bd79fd643942d8536",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "f5d8c05c82dddfc2b5394339c9ce10fd",
+          "qg_id": "e01"
+        },
+        {
+          "kg_id": "4307c21780ba9435f2ec841186fc1aef",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:7897",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0009757",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "5579d0ec3e69cf5bd79fd643942d8536",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "3a4faa96fda18467f20c57e2698a5969",
+          "qg_id": "e01"
+        },
+        {
+          "kg_id": "4a300978c71130b47e86455619ae437c",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:7897",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0020244",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "5579d0ec3e69cf5bd79fd643942d8536",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "5b4a451e1268a95b4730c621e832aa8b",
+          "qg_id": "e01"
+        },
+        {
+          "kg_id": "017e9913dedbc4d3af38ab478db90900",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:7897",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0020242",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "5579d0ec3e69cf5bd79fd643942d8536",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "adee1288f560956e607a04f76bc90838",
+          "qg_id": "e01"
+        },
+        {
+          "kg_id": "c76a335306c1a59c00829625f3fa79e2",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:7897",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0020238",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "5579d0ec3e69cf5bd79fd643942d8536",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "8da518c0ebf67fecacff4fe6b4341f11",
+          "qg_id": "e01"
+        },
+        {
+          "kg_id": "8cc5bc109a2887b23d10ac245c426758",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:7897",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0020143",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "5579d0ec3e69cf5bd79fd643942d8536",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "23aece11aac64f64fbdc5225f85ae3af",
+          "qg_id": "e01"
+        },
+        {
+          "kg_id": "9803d1f391fe69f2d28c1609d8b3a497",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:7897",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0020142",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "5579d0ec3e69cf5bd79fd643942d8536",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "875ac63cded21b98f6d17ec6434b5bac",
+          "qg_id": "e01"
+        },
+        {
+          "kg_id": "435a6e9d85c117b00867c124c4a37f1d",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:7897",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0017133",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "5579d0ec3e69cf5bd79fd643942d8536",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "5f1a25c39c27e23a12e003d91856e343",
+          "qg_id": "e01"
+        },
+        {
+          "kg_id": "d2093587dc8d1907b3d511120be8c278",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:7897",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0000429",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "5579d0ec3e69cf5bd79fd643942d8536",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "d38d4a36db0b03e15c28426dc43752a3",
+          "qg_id": "e01"
+        },
+        {
+          "kg_id": "9846510f8558d5904c58b42ab952c922",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:7897",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0016397",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "5579d0ec3e69cf5bd79fd643942d8536",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "fa4b08206af858e75510db7f2eec65c1",
+          "qg_id": "e01"
+        },
+        {
+          "kg_id": "e61eb002c27c93c42bbfd68ade1d458e",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:7897",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0010017",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "5579d0ec3e69cf5bd79fd643942d8536",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "92dec38d8ddffb1ec3957f6fb6e363c6",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:7897",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0016308",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "5579d0ec3e69cf5bd79fd643942d8536",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "e7bf683f8eec9a78876980b936c0e8bd",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:7897",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0016310",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "5579d0ec3e69cf5bd79fd643942d8536",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "0f844cbbd9e0f8ef23203e568c035c8e",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:7897",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0016309",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "5579d0ec3e69cf5bd79fd643942d8536",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "6e61c85fbf28cadd5365c88fc8fb0332",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:7897",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0016306",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "5579d0ec3e69cf5bd79fd643942d8536",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "4148488aa46bed29a30e746065e84316",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:7897",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0016307",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "5579d0ec3e69cf5bd79fd643942d8536",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "8e9e80763f608f704ea1dc7613b29e83",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:7897",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0020380",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "5579d0ec3e69cf5bd79fd643942d8536",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "7361a22b0bd99e435e77889cb8b65e97",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:7897",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0017719",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "5579d0ec3e69cf5bd79fd643942d8536",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "ef10ec35cc79bf0032b54f353fbfd715",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:7897",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0011719",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "39be31d4e134546a43882d14f945aeec",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "bc8cec26ab2c2ce305bf66a8792f4fd2",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:20818",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0019262",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "f30686d3a5edb8d62e319fa34920fec9",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "9afb31bdde377b93466d44301a1a759e",
+          "qg_id": "e01"
+        },
+        {
+          "kg_id": "f0e5841a8dd1d1813ce6859cb0a3e048",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:16361",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0019588",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "f30686d3a5edb8d62e319fa34920fec9",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "fbc007ea2597f9423d5fcd000aef0bc6",
+          "qg_id": "e01"
+        },
+        {
+          "kg_id": "7d508dca4af620c13ddb24bc5cee7de9",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:16361",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0006025",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "f30686d3a5edb8d62e319fa34920fec9",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "a88d6179a1575003c2d5d7a1ed912c37",
+          "qg_id": "e01"
+        },
+        {
+          "kg_id": "d98ec3a027618459ebb27d5cc5ec708d",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:16361",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0016298",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "f30686d3a5edb8d62e319fa34920fec9",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "e2f7ba2993d6b4d05ea2a97acb305a9a",
+          "qg_id": "e01"
+        },
+        {
+          "kg_id": "90fa46e46242ea7431159dcbb2d052a7",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:16361",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0016297",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "f30686d3a5edb8d62e319fa34920fec9",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "14d7e27b4775285337956da529a1e374",
+          "qg_id": "e01"
+        },
+        {
+          "kg_id": "790d09ff1574537211b1ab2061d7178d",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:16361",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0012662",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "f30686d3a5edb8d62e319fa34920fec9",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "1872bc68cf27fe5275d4f05f41a0fff3",
+          "qg_id": "e01"
+        },
+        {
+          "kg_id": "de338f46d2c865c1306a3d3af4b4d5f3",
+          "qg_id": "e01"
+        },
+        {
+          "kg_id": "d7eaeec59c7fcf27c8ea336e191601a2",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:16361",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0019200",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "f30686d3a5edb8d62e319fa34920fec9",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "109f0ce42854fcfd971c53fe565d98b3",
+          "qg_id": "e01"
+        },
+        {
+          "kg_id": "c73e3bd1ebda18b810e05ee4acb35def",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:16361",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0011767",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "f30686d3a5edb8d62e319fa34920fec9",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "67669afd50f8b405a96cdf6bbd322927",
+          "qg_id": "e01"
+        },
+        {
+          "kg_id": "66a851fea2dfd6eec9223b5cfcdecf3c",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:16361",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0019118",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "f30686d3a5edb8d62e319fa34920fec9",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "6d39c08044c1d4fc303b5fccebfadc0f",
+          "qg_id": "e01"
+        },
+        {
+          "kg_id": "bbdfe8de23ccd5bb27e004129b80959a",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:16361",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0023603",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "f30686d3a5edb8d62e319fa34920fec9",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "7043c5c6d13c04acde6ffadcd1c7affa",
+          "qg_id": "e01"
+        },
+        {
+          "kg_id": "cf90e39f3e7d80d84595bf7bd64ee58b",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:16361",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0000275",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "f30686d3a5edb8d62e319fa34920fec9",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "8594f5f3ace2358b02a50567aff09fff",
+          "qg_id": "e01"
+        },
+        {
+          "kg_id": "03532f464a7d1574133c6b9a4603d218",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:16361",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0020240",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "f30686d3a5edb8d62e319fa34920fec9",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "b57584541e714064e5f6ac8ca2bbb798",
+          "qg_id": "e01"
+        },
+        {
+          "kg_id": "c2a611028dc277518276c075e19fd637",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:16361",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0020238",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "f30686d3a5edb8d62e319fa34920fec9",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "f88d5132c2d327e1db9bf1e0d99d5097",
+          "qg_id": "e01"
+        },
+        {
+          "kg_id": "b31f28f221f3f7c8ea44d5318441aeb6",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:16361",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0000429",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "f30686d3a5edb8d62e319fa34920fec9",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "1ce6376d302bf13aa0d2645319103552",
+          "qg_id": "e01"
+        },
+        {
+          "kg_id": "5e03ac014213498f5b88d2b14d29d2bd",
+          "qg_id": "e01"
+        },
+        {
+          "kg_id": "b289c17ac16111cc0586d64e1ae61440",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:16361",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0016484",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "f30686d3a5edb8d62e319fa34920fec9",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "311d5920e28d96b99c3dfda0689b9828",
+          "qg_id": "e01"
+        },
+        {
+          "kg_id": "633dfcffcd41fe1543f42980aa76aca6",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:16361",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0019589",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "f30686d3a5edb8d62e319fa34920fec9",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "6d6c2034a641b7a634a36318ca2d6ceb",
+          "qg_id": "e01"
+        },
+        {
+          "kg_id": "a77742d4b029b9dbf3bd55957fa57767",
+          "qg_id": "e01"
+        },
+        {
+          "kg_id": "cf93c3bac618b3a1196da225e9078a38",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:16361",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0019501",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "f30686d3a5edb8d62e319fa34920fec9",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "860b7fd48e49ccb48fad4d3c9f98c66e",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:16361",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0019497",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "f30686d3a5edb8d62e319fa34920fec9",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "46345bb5090e444a54fce30d78ac7beb",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:16361",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0011080",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "f30686d3a5edb8d62e319fa34920fec9",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "d9dc1b3f3972ff4a3cf0ebfad122c5c8",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:16361",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0010576",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "f30686d3a5edb8d62e319fa34920fec9",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "d1724be72c0e2d857100bd1c872f5fa7",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:16361",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0017312",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "21ddd2f1adf8223c708b3ca60ac4e85e",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "a1512f83f35f1cc262091d011778e2a5",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:29249",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0011849",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "b4835feac457fe2140e3f5394cd09290",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "2c12d05820535e0cfbe7222f667cbc5a",
+          "qg_id": "e01"
+        },
+        {
+          "kg_id": "509d26c1dd7a0517c73d4cbe8f4b7bf7",
+          "qg_id": "e01"
+        },
+        {
+          "kg_id": "a5e000c14c184c57b21c832efcede470",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:30922",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0019502",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "b4835feac457fe2140e3f5394cd09290",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "f9997d4cf53426d4633dfe18e78bd33e",
+          "qg_id": "e01"
+        },
+        {
+          "kg_id": "2c1175ce9d7c5b3983550dd87f11b45a",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:30922",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0006025",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "b4835feac457fe2140e3f5394cd09290",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "cf371e56214fa6a66db2c1c39fa3ff55",
+          "qg_id": "e01"
+        },
+        {
+          "kg_id": "e4b13787609c5d597952ddbab2ad965e",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:30922",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0013702",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "b4835feac457fe2140e3f5394cd09290",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "51fcce977d8c8be6b4ebae89175aa55c",
+          "qg_id": "e01"
+        },
+        {
+          "kg_id": "d1ad281c8d8ccc993e4b03a0f75609f9",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:30922",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0000275",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "b4835feac457fe2140e3f5394cd09290",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "d9090cae0c3101d1a7e3523ecc42796b",
+          "qg_id": "e01"
+        },
+        {
+          "kg_id": "b919f4e2cf5332b3d09111b2c9011fc2",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:30922",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0000429",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "b4835feac457fe2140e3f5394cd09290",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "e65116e66807b5fc3f15135346e5a4d0",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:30922",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0011849",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "f8cfff67b05fe83baf3f51332921197e",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "9ab321d0a231b1418f9d2ef1910d3df0",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:24867",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0011849",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "707a6bbe3f735db98e9aa997ef3f6f41",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "ecc41c5a4a6d0ae6632ca4456ec754b8",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:13236",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0013674",
+          "qg_id": "n02"
+        }
+      ]
+    },
+    {
+      "edge_bindings": [
+        {
+          "kg_id": "2fab55008b84688f4203f10ca8db68e6",
+          "qg_id": "e00"
+        },
+        {
+          "kg_id": "6b56f24f52a2dbc161cb3feeffe32d4a",
+          "qg_id": "e01"
+        }
+      ],
+      "node_bindings": [
+        {
+          "kg_id": "MONDO:0005737",
+          "qg_id": "n00"
+        },
+        {
+          "kg_id": "HGNC:4669",
+          "qg_id": "n01"
+        },
+        {
+          "kg_id": "MONDO:0010383",
+          "qg_id": "n02"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,78 @@
+"""Test bl_compliance server.py"""
+import json
+from bl_compliance.server import app
+from starlette.testclient import TestClient
+from pathlib import Path
+
+
+ncats_json = Path(__file__).parent / 'resources' / 'ncats.json'
+robokop_json = Path(__file__).parent / 'resources' / 'robokop.json'
+inval_reasoner = Path(__file__).parent / 'resources' / 'inval-reasoner-std.json'
+inval_reasoner2 = Path(__file__).parent / 'resources' / 'inval-reasoner-std2.json'
+
+
+class TestServer():
+
+    @classmethod
+    def setup_class(self):
+        app.testing = True
+        self.test_client = TestClient(app)
+
+    @classmethod
+    def teardown_class(self):
+        self.test_client = None
+
+    def test_robokop(self):
+        """
+        Test output from robokop
+        """
+        robokop = open(robokop_json, 'r')
+        data = json.load(robokop)
+        robokop.close()
+
+        response = self.test_client.post('/validate/knowledge_graph', json=data)
+        assert response.status_code == 418
+
+    def test_ncats(self):
+        """
+        Test example for RSA validator
+        http://transltr.io:7071/apidocs/#/default/post_validate_knowledgegraph
+        """
+        ncats = open(ncats_json, 'r')
+        data = json.load(ncats)
+        ncats.close()
+        response = self.test_client.post('/validate/knowledge_graph', json=data)
+        assert response.status_code == 418
+        assert response.json()[0]['error_type'] == "TransformationError"
+
+    def test_inval_json(self):
+        """
+        Test that invalid reasoner std gets a 422 via pydantic type checking
+        """
+        bad_fh = open(inval_reasoner, 'r')
+        data = json.load(bad_fh)
+        bad_fh.close()
+        response = self.test_client.post('/validate/knowledge_graph', json=data)
+        assert response.status_code == 422
+
+    def test_inval_json_that_gets_passed_by_pydantic(self):
+        """
+        I suspect due to manually writing each dataclass __init__
+        (eg @dataclass(init=False)
+        pydantic does not correctly validate nested models
+        in this example edges[0].id is a dict instead of a str
+        but gets validated anyway
+
+        When we remove (init=False) the validatio works, but
+        then we can't support additionalProperties
+
+        Not a huge deal because the KGX validator catches it
+        and presumably the json schema validation will as well
+        """
+        bad_fh = open(inval_reasoner2, 'r')
+        data = json.load(bad_fh)
+        bad_fh.close()
+        response = self.test_client.post('/validate/knowledge_graph', json=data)
+        # If/when the above bug is fixable/fixed
+        #assert response.status_code == 422
+        assert response.status_code == 418

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,0 +1,44 @@
+"""Test bl_compliance validator.py"""
+from pathlib import Path
+import pytest
+import json
+from bl_compliance.validator import validate_with_jsonschema, validate_with_kgx
+
+
+biolink_json = Path(__file__).parent / 'resources' / 'biolink-compliant.json'
+robokop_json = Path(__file__).parent / 'resources' / 'robokop.json'
+
+
+@pytest.mark.skip(reason="Example not yet biolink compliant")
+def test_compliant_json_with_kgx():
+    """
+    Test bl compliant json with kgx validator
+    """
+    biolink_compliant = open(biolink_json, 'r')
+    data = json.load(biolink_compliant)
+    biolink_compliant.close()
+
+    errors = validate_with_kgx(data)
+
+    assert len(errors) == 0
+
+
+def test_robokop_with_kgx():
+    """
+    Test robokop json with kgx validator
+    """
+    robokop = open(robokop_json, 'r')
+    data = json.load(robokop)
+    robokop.close()
+
+    errors = validate_with_kgx(data)
+
+    assert len(errors) > 0
+
+
+@pytest.mark.skip(reason="test not implemented")
+def test_val_with_jsonschema():
+    """
+    Test stub for testing validation with json schema
+    """
+    assert True


### PR DESCRIPTION


Initializes a compliance service with two endpoints:

/validate/knowledge_graph/
- Checks a ReasonerAPI message for BioLink compliance 

/version
- returns the version of the biolink model json schema, and reasoner API std openAPI yaml

Json schema validation blocked by https://github.com/biolink/biolinkml/issues/33, https://github.com/biolink/biolink-model/issues/308

kgx validation is not quite working as expected, see
https://github.com/NCATS-Tangerine/kgx/issues/153
https://github.com/NCATS-Tangerine/kgx/issues/152
https://github.com/NCATS-Tangerine/kgx/issues/142
https://github.com/NCATS-Tangerine/kgx/issues/141
https://github.com/NCATS-Tangerine/kgx/issues/140

closes #1