### PR TITLE
Update for latest kgx validator changes

### DIFF
--- a/bl_compliance/models/errors.py
+++ b/bl_compliance/models/errors.py
@@ -1,7 +1,29 @@
 from dataclasses import dataclass
+from kgx.validator import ErrorType, MessageLevel
 
 
 @dataclass()
 class TransformationError:
     error_type: str
     message: str
+
+
+@dataclass()
+class KgxError():
+    """
+    This will eventually come from KGX
+    """
+    message_level: MessageLevel
+    error_type: ErrorType
+    element: str
+    error_message: str
+    details: str
+
+    def as_dict(self):
+        return {
+            'message_level': self.message_level.name,
+            'error_type': self.message_level.name,
+            'element': self.element,
+            'error_message': self.error_message,
+            'details': self.details
+        }

--- a/bl_compliance/models/errors.py
+++ b/bl_compliance/models/errors.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from kgx.validator import ErrorType, MessageLevel
 
 
 @dataclass()
@@ -9,24 +8,3 @@ class TransformationError:
 
     def as_dict(self):
         return vars(self)
-
-
-@dataclass()
-class KgxError():
-    """
-    This will eventually come from KGX
-    """
-    message_level: MessageLevel
-    error_type: ErrorType
-    element: str
-    error_message: str
-    details: str
-
-    def as_dict(self):
-        return {
-            'message_level': self.message_level.name,
-            'error_type': self.message_level.name,
-            'element': self.element,
-            'error_message': self.error_message,
-            'details': self.details
-        }

--- a/bl_compliance/models/errors.py
+++ b/bl_compliance/models/errors.py
@@ -7,6 +7,9 @@ class TransformationError:
     error_type: str
     message: str
 
+    def as_dict(self):
+        return vars(self)
+
 
 @dataclass()
 class KgxError():

--- a/bl_compliance/server.py
+++ b/bl_compliance/server.py
@@ -7,6 +7,7 @@ from typing import Union, Dict, Any, List
 from fastapi import FastAPI, Body
 from starlette.responses import JSONResponse
 from starlette.requests import Request
+from dataclasses import asdict
 from .validator import validate_with_jsonschema, validate_with_kgx
 from .models.knowledge_graph import KnowledgeGraph
 from .models.message import Message
@@ -41,7 +42,7 @@ biolink_schema = req.json()
 async def blvalidation_exception_handler(request: Request, exc: BlValidationException):
     return JSONResponse(
         status_code=418,
-        content=[content.__dict__ for content in exc.content],
+        content=[content.as_dict() for content in exc.content],
     )
 
 @app.post('/validate/knowledge_graph', response_model=Dict[Any, Any])

--- a/bl_compliance/server.py
+++ b/bl_compliance/server.py
@@ -7,7 +7,6 @@ from typing import Union, Dict, Any, List
 from fastapi import FastAPI, Body
 from starlette.responses import JSONResponse
 from starlette.requests import Request
-from dataclasses import asdict
 from .validator import validate_with_jsonschema, validate_with_kgx
 from .models.knowledge_graph import KnowledgeGraph
 from .models.message import Message

--- a/bl_compliance/validator.py
+++ b/bl_compliance/validator.py
@@ -4,18 +4,18 @@ using KGX and json schema
 """
 from typing import List, Union, Dict
 from kgx.transformers.rsa_transformer import RsaTransformer
-from kgx.validator import Validator, ErrorType, MessageLevel
+from kgx.validator import Validator, ErrorType, MessageLevel, ValidationError
 from dataclasses import asdict
 import fastjsonschema
 from jsonschema import validate as jsonvalidate
 from .models.knowledge_graph import KnowledgeGraph
 from .models.message import Message
-from .models.errors import TransformationError, KgxError
+from .models.errors import TransformationError
 
 
 def validate_with_kgx(
         data: Union[Dict, KnowledgeGraph, Message]
-) -> List[Union[KgxError, TransformationError]]:
+) -> List[Union[ValidationError, TransformationError]]:
     """
     Validate a rsa knowledge graph with kgx
 
@@ -49,18 +49,8 @@ def validate_with_kgx(
                         "message into biolink graph: {}".format(str(exc)),
         )]
     validator = Validator(verbose=True)
-    errors = validator.validate(biolinkified.graph)
 
-    # convert to list of errors to KgxErrors
-    kgx_errors = [KgxError(
-        message_level=MessageLevel[err[0]],
-        error_type=ErrorType[err[1]],
-        element=err[2],
-        error_message=err[3],
-        details=err[4]
-    ) for err in errors]
-
-    return kgx_errors
+    return validator.validate(biolinkified.graph)
 
 
 def validate_with_jsonschema(schema: Dict, data: Union[KnowledgeGraph, Message]):

--- a/bl_compliance/validator.py
+++ b/bl_compliance/validator.py
@@ -4,19 +4,18 @@ using KGX and json schema
 """
 from typing import List, Union, Dict
 from kgx.transformers.rsa_transformer import RsaTransformer
-from kgx.validator import Validator, NodeError, EdgeError
+from kgx.validator import Validator, ErrorType, MessageLevel
 from dataclasses import asdict
 import fastjsonschema
 from jsonschema import validate as jsonvalidate
 from .models.knowledge_graph import KnowledgeGraph
 from .models.message import Message
-from .models.errors import TransformationError
-
+from .models.errors import TransformationError, KgxError
 
 
 def validate_with_kgx(
         data: Union[Dict, KnowledgeGraph, Message]
-) -> List[Union[NodeError, EdgeError, TransformationError]]:
+) -> List[Union[KgxError, TransformationError]]:
     """
     Validate a rsa knowledge graph with kgx
 
@@ -49,10 +48,19 @@ def validate_with_kgx(
                 message="Could not transform reasoner "
                         "message into biolink graph: {}".format(str(exc)),
         )]
-    validator = Validator()
-    validator.validate(biolinkified.graph)
+    validator = Validator(verbose=True)
+    errors = validator.validate(biolinkified.graph)
 
-    return validator.errors
+    # convert to list of errors to KgxErrors
+    kgx_errors = [KgxError(
+        message_level=MessageLevel[err[0]],
+        error_type=ErrorType[err[1]],
+        element=err[2],
+        error_message=err[3],
+        details=err[4]
+    ) for err in errors]
+
+    return kgx_errors
 
 
 def validate_with_jsonschema(schema: Dict, data: Union[KnowledgeGraph, Message]):

--- a/tests/resources/biolink-compliant.json
+++ b/tests/resources/biolink-compliant.json
@@ -1,22 +1,132 @@
 {
-  "edges": [
-    {
-      "id": "553903",
-      "source_id": "https://omim.org/entry/603903",
-      "target_id": "http://www.uniprot.org/uniprot/P00738",
-      "edge_label": "affects"
-    }
-  ],
   "nodes": [
     {
-      "id": "OMIM:603903",
-      "name": "Haptoglobin",
-      "category": "Disease"
+      "id": "HGNC:11603",
+      "name": "TBX4",
+      "category": [
+        "biolink:Gene"
+      ]
     },
     {
-      "id": "UniProt:P00738",
-      "name": "HP",
-      "category": "Gene"
+      "id": "MONDO:0005002",
+      "name": "chronic obstructive pulmonary disease",
+      "category": [
+        "biolink:Disease"
+      ]
+    },
+    {
+      "id": "MONDO:0005002",
+      "name": "chronic obstructive pulmonary disease",
+      "category": [
+        "biolink:Disease"
+      ]
+    },
+    {
+      "id": "HGNC:11603",
+      "name": "TBX4",
+      "category": [
+        "biolink:Gene"
+      ]
+    },
+    {
+      "id": "MONDO:0013238",
+      "name": "chromosome 17q23.1-q23.2 deletion syndrome",
+      "category": [
+        "biolink:Disease"
+      ]
+    },
+    {
+      "id": "MONDO:0013238",
+      "name": "chromosome 17q23.1-q23.2 deletion syndrome",
+      "category": [
+        "biolink:Disease"
+      ]
+    },
+    {
+      "id": "HGNC:11603",
+      "name": "TBX4",
+      "category": [
+        "biolink:Gene"
+      ]
+    },
+    {
+      "id": "MONDO:0013329",
+      "name": "familial clubfoot due to 17q23.1q23.2 microduplication",
+      "category": [
+        "biolink:Disease"
+      ]
+    },
+    {
+      "id": "MONDO:0013329",
+      "name": "familial clubfoot due to 17q23.1q23.2 microduplication",
+      "category": [
+        "biolink:Disease"
+      ]
+    },
+    {
+      "id": "HGNC:11603",
+      "name": "TBX4",
+      "category": [
+        "biolink:Gene"
+      ]
+    },
+    {
+      "id": "MONDO:0017148",
+      "name": "heritable pulmonary arterial hypertension",
+      "category": [
+        "biolink:Disease"
+      ]
+    },
+    {
+      "id": "MONDO:0017148",
+      "name": "heritable pulmonary arterial hypertension",
+      "category": [
+        "biolink:Disease"
+      ]
+    },
+    {
+      "id": "HGNC:11603",
+      "name": "TBX4",
+      "category": [
+        "biolink:Gene"
+      ]
+    },
+    {
+      "id": "MONDO:0007841",
+      "name": "coxopodopatellar syndrome",
+      "category": [
+        "biolink:Disease"
+      ]
+    },
+    {
+      "id": "MONDO:0007841",
+      "name": "coxopodopatellar syndrome",
+      "category": [
+        "biolink:Disease"
+      ]
+    }
+  ],
+  "edges": [
+    {
+      "id": "a8575c4e-61a6-428a-bf09-fcb3e8d1644d",
+      "subject": "HGNC:11603",
+      "object": "MONDO:0005002",
+      "edge_label": "biolink:related_to",
+      "relation": "RO:0003304"
+    },
+    {
+      "id": "2d38345a-e9bf-4943-accb-dccba351dd04",
+      "subject": "HGNC:11603",
+      "object": "MONDO:0013238",
+      "edge_label": "biolink:related_to",
+      "relation": "RO:0003304"
+    },
+    {
+      "id": "d7edcb4b-af58-468a-8f86-ed737859693a",
+      "subject": "HGNC:11603",
+      "object": "MONDO:0013329",
+      "edge_label": "biolink:related_to",
+      "relation": "RO:0003304"
     }
   ]
 }

--- a/tests/resources/biolink-compliant.json
+++ b/tests/resources/biolink-compliant.json
@@ -127,6 +127,20 @@
       "object": "MONDO:0013329",
       "edge_label": "biolink:related_to",
       "relation": "RO:0003304"
+    },
+    {
+      "id": "044a7916-fba9-4b4f-ae48-f0815b0b222d",
+      "subject": "HGNC:11603",
+      "object": "MONDO:0017148",
+      "edge_label": "biolink:related_to",
+      "relation": "RO:0004013"
+    },
+    {
+      "id": "1a7f02a7-24ab-4480-809d-f61e80876b70",
+      "subject": "HGNC:11603",
+      "object": "MONDO:0007841",
+      "edge_label": "biolink:related_to",
+      "relation": "RO:0004013"
     }
   ]
 }

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -19,7 +19,7 @@ def test_compliant_json_with_kgx():
 
     errors = validate_with_kgx(data)
 
-    assert len(errors) == 1
+    assert len(errors) == 0
 
 
 def test_robokop_with_kgx():

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -9,7 +9,6 @@ biolink_json = Path(__file__).parent / 'resources' / 'biolink-compliant.json'
 robokop_json = Path(__file__).parent / 'resources' / 'robokop.json'
 
 
-@pytest.mark.skip(reason="Example not yet biolink compliant")
 def test_compliant_json_with_kgx():
     """
     Test bl compliant json with kgx validator
@@ -20,7 +19,7 @@ def test_compliant_json_with_kgx():
 
     errors = validate_with_kgx(data)
 
-    assert len(errors) == 0
+    assert len(errors) == 1
 
 
 def test_robokop_with_kgx():


### PR DESCRIPTION
Updates to work with the latest kgx validator PR: https://github.com/NCATS-Tangerine/kgx/pull/154

- Changes in validator object, returns a list of tuples instead adding instance variable validator.error
- Replaces NodeError and EdgeError with KgxError (based on tuple)
- Adds compliant JSON to mirror kgx validator test - https://github.com/NCATS-Tangerine/kgx/pull/154/files#diff-e27a66043ef27061182893bb396a2c84

still working out some details with the kgx validator as the "compliant" json is returning errors for missing association ids

Edit: above fixed with NCATS-Tangerine/kgx#156